### PR TITLE
Unblock blocked signals after forking off a child

### DIFF
--- a/service.c
+++ b/service.c
@@ -278,6 +278,8 @@ int service_start(svc_t *svc)
 			_e("%starting %s: %s", respawn ? "Res" : "S", svc->cmd, buf);
 		}
 
+		sig_unblock();
+
 		if (svc->inetd.cmd)
 			status = svc->inetd.cmd(svc->inetd.type);
 		else

--- a/sig.c
+++ b/sig.c
@@ -188,6 +188,7 @@ void sig_unblock(void)
 	struct sigaction sa;
 
 	sigemptyset(&nmask);
+	sigaddset(&nmask, SIGHUP);
 	sigaddset(&nmask, SIGCHLD);
 	sigaddset(&nmask, SIGINT);
 	sigaddset(&nmask, SIGPWR);


### PR DESCRIPTION
After forking off a new child, all signals that are blocked by finit
should be unblocked before exec-ing the final binary. Also, finit now
blocks SIGHUP, so add it to the set of signals that should be
unblocked.