### PR TITLE
Westermo fixes for services changing type at runtime

### DIFF
--- a/service.c
+++ b/service.c
@@ -616,6 +616,7 @@ int service_register(int type, char *line, time_t mtime, char *username)
 
 		id = svc_next_id(cmd);
 	}
+recreate:
 #endif
 
 	svc = svc_find(cmd, id);
@@ -625,6 +626,13 @@ int service_register(int type, char *line, time_t mtime, char *username)
 		if (!svc) {
 			_e("Out of memory, cannot register service %s", cmd);
 			return errno = ENOMEM;
+		}
+	} else {
+		if (svc_is_inetd(svc) && type != SVC_TYPE_INETD) {
+			_d("Service was previously inetd, deregistering ...");
+			inetd_del(&svc->inetd);
+			svc_del(svc);
+			goto recreate;
 		}
 	}
 

--- a/svc.c
+++ b/svc.c
@@ -97,9 +97,7 @@ svc_t *svc_new(char *cmd, int id, int type)
  */
 int svc_del(svc_t *svc)
 {
-	/* Clear any old references and set SVC_TYPE_FREE */
-	memset(svc, 0, sizeof(*svc));
-
+	svc->type = SVC_TYPE_FREE;
 	return 0;
 }
 


### PR DESCRIPTION
This patch series is primarily for handling a bug when changing a service from inetd to regular service. The problem was that the Finit inetd socket was not closed, effectively preventing the (new) service to bind to its port.