### PR TITLE
Fix SIGSEGV due to writes to const char array.

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -519,10 +519,12 @@ int conf_parse_config(void)
 
 	result = parse_conf(FINIT_CONF);
 	if (!tty_num()) {
-		char *fallback = FALLBACK_SHELL;
+		char *fallback = NULL;
 
 		if (console)
 			fallback = console;
+		else
+			fallback = strdup(FALLBACK_SHELL);
 
 		tty_register(fallback);
 	}


### PR DESCRIPTION
If no console is configured, then the following code gets executed:

    int conf_parse_config(void)
    {
       ...
       char *fallback = FALLBACK_SHELL;
       ...
       tty_register(fallback);
       ...
     }
    
     int tty_register(char *line)
     {
       ...
       cmd = strtok(line, " ");
       ...
     }

`FALLBACK_SHELL` is constant character array and `strtok()` tries to modify the first argument, which causes a crash.