### PR TITLE
service: kill stubborn services, wait before restart

### DIFF
--- a/finit.h
+++ b/finit.h
@@ -34,6 +34,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <lite/lite.h>
+#include <uev/uev.h>
 
 #define CMD_SIZE                256
 #define LINE_SIZE               1024
@@ -90,6 +91,8 @@ extern char  *hostname;
 extern char  *username;
 extern char  *runparts;
 extern char  *console;
+extern uev_ctx_t *ctx;
+
 extern char  *__progname;
 
 #endif /* FINIT_H_ */

--- a/helpers.c
+++ b/helpers.c
@@ -127,6 +127,7 @@ void print(int action, const char *fmt, ...)
 	va_list ap;
 	const char success[] = " \e[1m[ OK ]\e[0m\n";
 	const char failure[] = " \e[7m[FAIL]\e[0m\n";
+	const char warning[] = " \e[7m[WARN]\e[0m\n";
 	const char pending[] = " \e[1m[ \\/ ]\e[0m\n";
 	const char dots[] = " .....................................................................";
 
@@ -156,6 +157,10 @@ void print(int action, const char *fmt, ...)
 
 	case 1:
 		write(STDERR_FILENO, failure, sizeof(failure));
+		break;
+
+	case 2:
+		write(STDERR_FILENO, warning, sizeof(warning));
 		break;
 
 	default:

--- a/svc.c
+++ b/svc.c
@@ -443,6 +443,9 @@ char *svc_status(svc_t *svc)
 
 		case SVC_BLOCK_INETD_BUSY:
 			return "busy";
+
+		case SVC_BLOCK_RESTARTING:
+			return "restart";
 		}
 
 	case SVC_DONE_STATE:

--- a/svc.h
+++ b/svc.h
@@ -65,6 +65,7 @@ typedef enum {
 	SVC_BLOCK_CRASHING,
 	SVC_BLOCK_USER,
 	SVC_BLOCK_INETD_BUSY,
+	SVC_BLOCK_RESTARTING,
 } svc_block_t;
 
 #define FINIT_SHM_ID     0x494E4954  /* "INIT", see ascii(7) */
@@ -123,6 +124,11 @@ typedef struct svc {
 	int	       dynamic_stop;
 	int	       private;
 	svc_cmd_t    (*cb)(struct svc *svc, int event, void *event_arg);
+
+	/* Used to forcefully kill services that won't shutdown on
+	 * termination and to delay restarts of crashing services. */
+	uev_t          timer;
+	void           (*timer_cb)(struct svc *svc);
 } svc_t;
 
 typedef struct svc_map svc_map_t;


### PR DESCRIPTION
Add support for registering callbacks to be called after a given
timeout.

Use this to implement forceful termination of services that refuse to
terminate upon receiving a SIGTERM. If the service PID is not collected
within 3 seconds, send a SIGKILL to it.

Also, rework restarting of crashing services. When a service crashes for
the first time, try to restart it immediately. If it crashes again, wait
a few seconds before trying again. Just as before, if it continues to
crash, block the service.