### PR TITLE
run: fix array overflow

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -91,7 +91,7 @@ int run(char *cmd)
 	}
 	args[i] = NULL;
 
-	if (i == NUM_ARGS && args[i]) {
+	if (i == NUM_ARGS && arg) {
 		_e("Command too long: %s", cmd);
 		free(backup);
 		errno = EOVERFLOW;


### PR DESCRIPTION
Looks like array overflow checking in `run()` was broken. Condition `(i == NUM_ARGS && args[i])` right after `args[i] = NULL` was always false. I wrote some test to recheck it:
```c
#include <errno.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

#define NUM_ARGS 16

int run(char *cmd)
{
    int status, result, i = 0;
    char *args[NUM_ARGS + 1], *arg, *backup;
    pid_t pid;

    /* We must create a copy that is possible to modify. */
    backup = arg = strdup(cmd);
    if (!arg)
        return 1; /* Failed allocating a string to be modified. */

    /* Split command line into tokens of an argv[] array. */
    args[i++] = strsep(&arg, "\t ");
    while (arg && i < NUM_ARGS) {
        /* Handle run("su -c \"dbus-daemon --system\" messagebus");
         *   => "su", "-c", "\"dbus-daemon --system\"", "messagebus" */
        if (*arg == '\'' || *arg == '"') {
            char *p, delim[2] = " ";

            delim[0]  = arg[0];
            args[i++] = arg++;
            strsep(&arg, delim);
            p     = arg - 1;
            *p     = *delim;
            *arg++ = 0;
        } else {
            args[i++] = strsep(&arg, "\t ");
        }
    }
    args[i] = NULL;

    if (i == NUM_ARGS && args[i]) {
        printf("Command too long: %s\n", cmd);
        printf("rest: %s\n", arg);
        free(backup);
        errno = EOVERFLOW;
        return 1;
    } else {
        printf("all good: %s\n", cmd);
        return 0;
    }
}


int main(void)
{
    run("one two thee four five six seven eight nine ten eleven twelve"//);
        " thirteen fourteen fifteen sixteen seventeen");
    return 0;
}

```
Result:
```
$ gcc -o strsep strsep.c
$ ./strsep 
all good: one two thee four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen
$ 
```

After changing `args[i]` to `arg` all cheks are done just fine:
```
$ ./strsep
Command too long: one two thee four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen
rest: seventeen
$

```