### PR TITLE
Fix fluxstate

### DIFF
--- a/service.c
+++ b/service.c
@@ -538,7 +538,7 @@ void service_runlevel(int newlevel)
  * Returns:
  * POSIX OK(0) on success, or non-zero errno exit status on failure.
  */
-int service_register(int type, char *line, time_t mtime, char *username)
+int service_register(int type, char *line, struct timeval *mtime, char *username)
 {
 	int i = 0;
 	int id = 1;		/* Default to ID:1 */

--- a/service.h
+++ b/service.h
@@ -28,7 +28,7 @@
 #include "svc.h"
 
 void	  service_runlevel	 (int newlevel);
-int	  service_register	 (int type, char *line, time_t mtime, char *username);
+int	  service_register	 (int type, char *line, struct timeval *mtime, char *username);
 void      service_unregister     (svc_t *svc);
 int       service_enabled	 (svc_t *svc);
 

--- a/svc.c
+++ b/svc.c
@@ -24,6 +24,7 @@
 
 #include <stdlib.h>
 #include <strings.h>
+#include <sys/time.h>
 
 #include "finit.h"
 #include "svc.h"
@@ -172,7 +173,7 @@ svc_t *svc_dynamic_iterator(int first)
 	svc_t *svc;
 
 	for (svc = svc_iterator(first); svc; svc = svc_iterator(0)) {
-		if (svc->mtime)
+		if (svc->mtime.tv_sec)
 			return svc;
 	}
 
@@ -415,13 +416,15 @@ void svc_mark_clean(svc_t *svc)
 	*((int *)&svc->dirty) = 0;
 }
 
-void svc_check_dirty(svc_t *svc, time_t mtime)
+void svc_check_dirty(svc_t *svc, struct timeval *mtime)
 {
-	if (svc->mtime != mtime)
+	if (mtime && timercmp(&svc->mtime, mtime, !=))
 		svc_mark_dirty(svc);
 	else
 		svc_mark_clean(svc);
-	svc->mtime = mtime;
+
+	svc->mtime.tv_sec = mtime ? mtime->tv_sec : 0;
+	svc->mtime.tv_usec = mtime ? mtime->tv_usec : 0;
 }
 
 /**

--- a/svc.h
+++ b/svc.h
@@ -86,7 +86,7 @@ typedef struct svc {
 	pid_t	       pid;
 	const svc_state_t state;       /* Paused, Reloading, Restart, Running, ... */
 	svc_type_t     type;
-	time_t	       mtime;	       /* Modification time for .conf from /etc/finit.d/ */
+	struct timeval mtime;          /* Modification time for .conf from /etc/finit.d/ */
 	const int      dirty;	       /* Set if old mtime != new mtime  => reloaded,
 					* or -1 when marked for removal */
 	int            starting;       /* ... waiting for pidfile to be re-asserted */
@@ -160,7 +160,7 @@ void      svc_foreach_type     (int types, void (*cb)(svc_t *));
 int       svc_stop_completed   (void);
 
 void	  svc_mark_dynamic     (void);
-void	  svc_check_dirty      (svc_t *svc, time_t mtime);
+void	  svc_check_dirty      (svc_t *svc, struct timeval *mtime);
 void	  svc_mark_dirty       (svc_t *svc);
 void	  svc_mark_clean       (svc_t *svc);
 void	  svc_clean_dynamic    (void (*cb)(svc_t *));
@@ -177,7 +177,7 @@ static inline void svc_starting    (svc_t *svc) { svc->starting = 1;         }
 static inline void svc_started     (svc_t *svc) { svc->starting = 0;         }
 static inline int  svc_is_starting (svc_t *svc) { return 0 != svc->starting; }
 
-static inline int svc_is_dynamic   (svc_t *svc) { return svc &&  0 != svc->mtime; }
+static inline int svc_is_dynamic   (svc_t *svc) { return svc &&  0 != svc->mtime.tv_sec; }
 static inline int svc_is_removed   (svc_t *svc) { return svc && -1 == svc->dirty; }
 static inline int svc_is_changed   (svc_t *svc) { return svc &&  0 != svc->dirty; }
 static inline int svc_is_updated   (svc_t *svc) { return svc &&  1 == svc->dirty; }


### PR DESCRIPTION
There are some problems with applications stay in flux state/never become flux state.

* If an appliciation depend on an application run later in the service list it will be kept in flux
* When running on X86, finit sometimes complete its operation on below 1 s, the timestamp used to detect if any service is dirty is only using seconds.
