### PR TITLE
Some cleanup

### DIFF
--- a/src/finit.c
+++ b/src/finit.c
@@ -252,6 +252,11 @@ int main(int argc, char* argv[])
 	ctx = &loop;
 
 	/*
+	 * Set the PATH early to something sane
+	 */
+	setenv("PATH", _PATH_STDPATH, 1);
+
+	/*
 	 * Mount base file system, kernel is assumed to run devtmpfs for /dev
 	 */
 	chdir("/");
@@ -339,9 +344,6 @@ int main(int argc, char* argv[])
 
 	/* Set hostname as soon as possible, for syslog et al. */
 	set_hostname(&hostname);
-
-	/* Set default PATH, for uid 0 */
-	setenv("PATH", _PATH_STDPATH, 1);
 
 	/*
 	 * Mount filesystems

--- a/src/finit.c
+++ b/src/finit.c
@@ -155,36 +155,39 @@ static void networking(void)
 		return;
 	}
 
-	/* Debian/Ubuntu/Busybox interfaces file */
-	fp = fopen("/etc/network/interfaces", "r");
-	if (fp) {
-		int i = 0;
-		char buf[160];
+	/* Debian/Ubuntu/Busybox/RH/Suse */
+	if (fexist("/sbin/ifup")) {
+		/* interfaces file */
+		fp = fopen("/etc/network/interfaces", "r");
+		if (fp) {
+			int i = 0;
+			char buf[160];
 
-		/* Bring up all 'auto' interfaces */
-		while (fgets(buf, sizeof(buf), fp)) {
-			char cmd[80];
-			char *line, *ifname = NULL;
+			/* Bring up all 'auto' interfaces */
+			while (fgets(buf, sizeof(buf), fp)) {
+				char cmd[80];
+				char *line, *ifname = NULL;
 
-			chomp(buf);
-			line = strip_line(buf);
+				chomp(buf);
+				line = strip_line(buf);
 
-			if (!strncmp(line, "auto", 4))
-				ifname = &line[5];
- 			if (!strncmp(line, "allow-hotplug", 13))
-				ifname = &line[14];
+				if (!strncmp(line, "auto", 4))
+					ifname = &line[5];
+				if (!strncmp(line, "allow-hotplug", 13))
+					ifname = &line[14];
 
-			if (!ifname)
-				continue;
+				if (!ifname)
+					continue;
 
-			snprintf(cmd, 80, "/sbin/ifup %s", ifname);
-			run_interactive(cmd, "Bringing up interface %s", ifname);
-			i++;
+				snprintf(cmd, 80, "/sbin/ifup %s", ifname);
+				run_interactive(cmd, "Bringing up interface %s", ifname);
+				i++;
+			}
+
+			fclose(fp);
+			if (i)
+				return;
 		}
-
-		fclose(fp);
-		if (i)
-			return;
 	}
 
 	/* Fall back to bring up at least loopback */

--- a/src/finit.h
+++ b/src/finit.h
@@ -36,6 +36,16 @@
 #include <lite/lite.h>
 #include <uev/uev.h>
 
+/* just in case */
+#ifndef _PATH_STDPATH
+#define _PATH_STDPATH   "/usr/bin:/bin:/usr/sbin:/sbin"
+#endif
+
+#ifndef _PATH_VARRUN
+#define _PATH_VARRUN    "/var/run/"
+#endif
+
+
 #define CMD_SIZE                256
 #define LINE_SIZE               1024
 #define BUF_SIZE                4096


### PR DESCRIPTION
PATCH 1 + 2 is about the PATh changes discuss from PR #70 , however this solves just the 
run(/bin/foo); -> run('foo"); part.. fexist() function would need  some changes but using
stat() and friends for it would be a bit to much I guess.. 
( maybe we find a solution for that in #71 too )
However I think is not bad to have an fallback for the PATHs in case something breaks 
and having the PATH setup early is not bad too.

PATCH 3 is a Distro thing , however we really should check ifup exists before trying to use it.

Regards