### PR TITLE
inetd: remove ntoh on proto

### DIFF
--- a/src/inetd.c
+++ b/src/inetd.c
@@ -573,7 +573,7 @@ int inetd_match(inetd_t *inetd, char *service, char *proto)
 	if (getent(service, proto, &sv, &pv))
 		return 0;
 
-	if (inetd->proto == ntohs(pv->p_proto) &&
+	if (inetd->proto == pv->p_proto &&
 	    inetd->port  == ntohs(sv->s_port))
 		return 1;
 


### PR DESCRIPTION
getprotobyname() returns p_proto in host endian, so it should not be
converted with ntoh. (Note: getservbyname() on the other hand does
return s_port in network endian)

Signed-off-by: Petrus Hellgren <petrus.hellgren@westermo.se>