### PR TITLE
helpers.h: fix build error: unknown type name ‘va_list’

### DIFF
--- a/src/helpers.h
+++ b/src/helpers.h
@@ -25,6 +25,7 @@
 #ifndef FINIT_HELPERS_H_
 #define FINIT_HELPERS_H_
 
+#include <stdarg.h>
 #include <sys/types.h>
 #include <lite/lite.h>
 #include "log.h"


### PR DESCRIPTION
Building finit with a uclibc-ng-toolchain fails with:
```
../src/helpers.h:53:43: error: unknown type name ‘va_list’
 void    printv          (const char *fmt, va_list ap);
```