### PR TITLE
Do not try to SIGKILL inetd services, they are not backed by a pid

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -966,7 +966,8 @@ static void svc_set_state(svc_t *svc, svc_state_t new)
 	*state = new;
 
 	/* if the PID isn't collected within 3s, kill it! */
-	if (*state == SVC_STOPPING_STATE) {
+	if ((*state == SVC_STOPPING_STATE) &&
+	    !svc_is_inetd(svc)) {
 		service_timeout_cancel(svc);
 		service_timeout_after(svc, 3000, service_kill);
 	}


### PR DESCRIPTION
As a precaution, services who are being stopped are automatically sent
a SIGKILL after 3 seconds if they refuse to go away willingly.

Unfortunately this backup mechanism was also enabled for inetd
services which are not backed by a real process. When the service was
freed the timer was not stopped, since it was not expected to be
armed. The timer would then trigger, causing a use-after-free on the
timer watcher containing a bogus callback pointer.