### PR TITLE
Only restart inetd services when neccessary

### DIFF
--- a/src/inetd.h
+++ b/src/inetd.h
@@ -58,6 +58,7 @@ int     inetd_check_loop(struct sockaddr *sa, socklen_t len, char *name);
 
 int     inetd_start     (inetd_t *inetd);
 void    inetd_stop      (inetd_t *inetd);
+void    inetd_stop_children (inetd_t *inetd, int check_allowed);
 
 int     inetd_new       (inetd_t *inetd, char *name, char *service, char *proto, int forking, svc_t *svc);
 int     inetd_del       (inetd_t *inetd);

--- a/src/service.c
+++ b/src/service.c
@@ -1114,9 +1114,11 @@ restart:
 						break;
 					service_restart(svc);
 				} else {
+#ifdef INETD_ENABLED
 					if (svc_is_inetd(svc))
 						inetd_stop_children(&svc->inetd, 1);
 					else
+#endif
 						service_stop(svc);
 				}
 				svc_mark_clean(svc);

--- a/src/service.c
+++ b/src/service.c
@@ -1114,7 +1114,10 @@ restart:
 						break;
 					service_restart(svc);
 				} else {
-					service_stop(svc);
+					if (svc_is_inetd(svc))
+						inetd_stop_children(&svc->inetd, 1);
+					else
+						service_stop(svc);
 				}
 				svc_mark_clean(svc);
 			}

--- a/src/svc.h
+++ b/src/svc.h
@@ -109,6 +109,7 @@ typedef struct svc {
 	/* For inetd services */
 	inetd_t        inetd;
 	int            stdin_fd;
+	char           iifname[IF_NAMESIZE];  /* Ingress interface for connection */
 
 	/* Set for services we need to redirect stdout/stderr to syslog */
 	struct {


### PR DESCRIPTION
Do not restart a inetd service if the listening interface is changed. Only bring down established connection which are no longer allowed, i.e. do not touch already allowed established connections.
