### PR TITLE
Add support to specify service ID as a string

### DIFF
--- a/src/finit.c
+++ b/src/finit.c
@@ -222,7 +222,7 @@ static void finalize(void)
 	/*
 	 * Track bundled watchdogd in case a better one turns up
 	 */
-	svc = svc_find(FINIT_LIBPATH_ "/watchdogd", 1);
+	svc = svc_find(FINIT_LIBPATH_ "/watchdogd", "1");
 	if (svc)
 		wdog = svc;
 

--- a/src/inetd.c
+++ b/src/inetd.c
@@ -169,6 +169,7 @@ static void socket_cb(uev_t *w, void *arg, int events)
 	svc_t *svc = (svc_t *)arg, *task;
 	const char *conn = " connection";
 	char iifname[IF_NAMESIZE + 1] = "UNKNOWN";
+	char id[MAX_ID_LEN];
 	int stdin;
 
 	_d("%s: Got socket event ...", svc->cmd);
@@ -194,7 +195,8 @@ static void socket_cb(uev_t *w, void *arg, int events)
 		return;
 	}
 
-	task = svc_new(svc->cmd, svc->inetd.next_id++, SVC_TYPE_INETD_CONN);
+	snprintf(id, sizeof(id), "%d", svc->inetd.next_id++);
+	task = svc_new(svc->cmd, id, SVC_TYPE_INETD_CONN);
 	if (!task) {
 		logit(LOG_CRIT, "%s: Unable to allocate service for inetd client", svc->cmd);
 		if (svc->inetd.type == SOCK_STREAM)

--- a/src/initctl.c
+++ b/src/initctl.c
@@ -438,12 +438,12 @@ static int show_status(char *arg)
 		printheader(NULL, "#         STATUS   PID     RUNLEVELS     SERVICE           DESCRIPTION", 0);
 
 	for (svc = client_svc_iterator(1); svc; svc = client_svc_iterator(0)) {
-		char jobid[10], args[512] = "", *lvls;
+		char jobid[20], args[512] = "", *lvls;
 
 //		if (svc_is_unique(svc))
 //			snprintf(jobid, sizeof(jobid), "%d", svc->job);
 //		else
-			snprintf(jobid, sizeof(jobid), "%d:%d", svc->job, svc->id);
+			snprintf(jobid, sizeof(jobid), "%d:%s", svc->job, svc->id);
 
 		printf("%-9s %7s  ", jobid, svc_status(svc));
 		if (svc_is_inetd(svc))

--- a/src/svc.h
+++ b/src/svc.h
@@ -66,6 +66,7 @@ typedef enum {
 	SVC_BLOCK_RESTARTING,
 } svc_block_t;
 
+#define MAX_ID_LEN       16
 #define MAX_ARG_LEN      64
 #define MAX_STR_LEN      64
 #define MAX_COND_LEN     (MAX_ARG_LEN * 3)
@@ -86,7 +87,8 @@ typedef struct svc {
 	TAILQ_ENTRY(svc) link;
 
 	/* Instance specifics */
-	int            job, id;	       /* JOB:ID */
+	int            job;	       /* JOB: */
+	char           id[MAX_ID_LEN]; /* :ID */
 
 	/* Limits and scoping */
 	struct rlimit  rlimit[RLIMIT_NLIMITS];
@@ -145,13 +147,13 @@ typedef struct svc {
 	struct timespec gc;
 } svc_t;
 
-svc_t      *svc_new                (char *cmd, int id, int type);
+svc_t      *svc_new                (char *cmd, char *id, int type);
 int	    svc_del	           (svc_t *svc);
 
-svc_t	   *svc_find	           (char *cmd, int id);
+svc_t	   *svc_find	           (char *cmd, char *id);
 svc_t	   *svc_find_by_pid        (pid_t pid);
-svc_t	   *svc_find_by_jobid      (int job, int id);
-svc_t	   *svc_find_by_nameid     (char *name, int id);
+svc_t	   *svc_find_by_jobid      (int job, char *id);
+svc_t	   *svc_find_by_nameid     (char *name, char *id);
 svc_t      *svc_find_by_pidfile    (char *fn);
 
 svc_t      *svc_iterator           (svc_t **iter, int first);
@@ -172,10 +174,10 @@ int	    svc_clean_bootstrap    (svc_t *svc);
 void	    svc_prune_bootstrap	   (void);
 
 int         svc_enabled            (svc_t *svc);
-int         svc_next_id            (char  *cmd);
+int         svc_next_id_int        (char  *cmd);
 int         svc_is_unique          (svc_t *svc);
 
-int         svc_parse_jobstr       (char *str, size_t len, int (*found)(svc_t *), int (not_found)(char *, int));
+int         svc_parse_jobstr       (char *str, size_t len, int (*found)(svc_t *), int (not_found)(char *, char *));
 
 static inline int svc_is_inetd     (svc_t *svc) { return svc && SVC_TYPE_INETD      == svc->type; }
 static inline int svc_is_inetd_conn(svc_t *svc) { return svc && SVC_TYPE_INETD_CONN == svc->type; }


### PR DESCRIPTION
Add support to specify service ID as a string.

Sample output:
```
admin@zero:~ # initctl stop udhcpc:eth1
admin@zero:~ # initctl status
#         STATUS   PID     RUNLEVELS     SERVICE           DESCRIPTION
3:1       running  977     [S123456789]  klogd             Kernel log daemon
9:1       running  976     [S123456789]  watchdogd         System watchdog daemon
22:eth0   running  1432    [---3-----9]  udhcpc            DHCP client (eth0)
22:eth1   stopped  0       [---3-----9]  udhcpc            DHCP client (eth1)
22:eth2   running  1452    [---3-----9]  udhcpc            DHCP client (eth2)
```