### PR TITLE
Switch to using nanosleep in favour of sleep

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
 #include <sys/sysinfo.h>	/* sysinfo() */
 #include <lite/lite.h>		/* strlcat() */
@@ -105,7 +106,11 @@ int strtobytes(char *arg)
 
 void do_sleep(unsigned int sec)
 {
-	while ((sec = sleep(sec)))
+	struct timespec requested_sleep = {
+		.tv_sec = sec,
+		.tv_nsec = 0,
+	};
+	while (nanosleep(&requested_sleep, &requested_sleep))
 		;
 }
 


### PR DESCRIPTION
The remaining sleep time returned by sleep is not accurate enough to be
used as a means to achieve "signal safe"-sleep. nanosleep can be used
in similar fashion instead and is granular enough for our purposes.

This issue was identified during reboot, when Finit is bombarded with
SIGCHLD, aborting the sleep that we do to give daemons a chance to shut
down gracefully. The total delay ended up being less than a second when
in fact two seconds were the intended delay.