### PR TITLE
[RFC] Boot refactor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,7 @@ AC_ARG_ENABLE(contrib,
 enable_all_plugins=auto
 AC_PLUGIN([alsa-utils],    [no],  [Save and restore ALSA sound settings using alsactl])
 AC_PLUGIN([dbus],          [no],  [Setup and start system message bus, D-Bus])
+AC_PLUGIN([hotplug],       [yes], [Setup and start udev or mdev hotplug daemon])
 AC_PLUGIN([inetd-echo],    [no],  [Inetd plugin: echo server, RFC862])
 AC_PLUGIN([inetd-chargen], [no],  [Inetd plugin: character generator, RFC864])
 AC_PLUGIN([inetd-daytime], [no],  [Inetd plugin: daytime server, RFC867])

--- a/contrib/fstab.bb
+++ b/contrib/fstab.bb
@@ -1,0 +1,15 @@
+# This is a basic /etc/fstab that mounts up all of the virtual filesystems
+# that older versions of Finit used to mount internally. It can serve as a
+# starting point for systems running Busybox's mount implementation. Make
+# sure that CONFIG_FEATURE_MOUNT_HELPERS enabled; as this is required
+# create the /dev/{pts,shm} directories.
+
+devtmpfs	/dev		devtmpfs	defaults		0	0
+mkdir#-p	/dev/pts	helper		none			0	0
+devpts		/dev/pts	devpts		mode=620,ptmxmode=0666	0	0
+mkdir#-p	/dev/shm	helper		none			0	0
+tmpfs		/dev/shm	tmpfs		mode=0777		0	0
+proc		/proc		proc		defaults		0	0
+tmpfs		/tmp		tmpfs		mode=1777,nosuid,nodev	0	0
+tmpfs		/run		tmpfs		mode=0755,nosuid,nodev	0	0
+sysfs		/sys		sysfs		defaults		0	0

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -42,6 +42,9 @@ For your convenience a set of *optional* plugins are available:
 
 * *discard.so*: RFC 863 plugin.  Start as inetd service, like time below.
 
+* *hotplug.so*: Setup and start either udev or mdev hotplug daemon, if
+  available.
+
 * *rtc.so*: Restore and save system clock from/to RTC on boot/halt.
 
 * *initctl.so*: Extends finit with a traditional `initctl` functionality.

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -17,6 +17,10 @@ if BUILD_DBUS_PLUGIN
 libplug_la_SOURCES += dbus.c
 endif
 
+if BUILD_HOTPLUG_PLUGIN
+libplug_la_SOURCES += hotplug.c
+endif
+
 if INETD
 if BUILD_INETD_ECHO_PLUGIN
 libplug_la_SOURCES += echo.c
@@ -60,6 +64,10 @@ endif
 
 if BUILD_DBUS_PLUGIN
 pkglib_LTLIBRARIES += dbus.la
+endif
+
+if BUILD_HOTPLUG_PLUGIN
+pkglib_LTLIBRARIES += hotplug.la
 endif
 
 if INETD

--- a/plugins/hotplug.c
+++ b/plugins/hotplug.c
@@ -1,0 +1,110 @@
+/* Heuristically find and initialize a suitable hotplug daemon
+ *
+ * Copyright (c) 2012-2020 Joachim Wiberg <troglobit@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <stdio.h>
+
+#include "config.h"
+#include "conf.h"
+#include "finit.h"
+#include "helpers.h"
+#include "plugin.h"
+#include "service.h"
+
+static void setup(void *arg)
+{
+	char cmd[256];
+	char *path;
+
+	/*
+	 * Populate /dev and prepare for runtime events from kernel.
+	 * Prefer udev if mdev is also available on the system.
+	 */
+	path = which("udevd");
+	if (!path)
+		path = which("/lib/systemd/systemd-udevd");
+	if (path) {
+		/* Register udevd as a monitored service */
+		snprintf(cmd, sizeof(cmd), "[S12345789] pid:udevd %s "
+			 "-- Device event managing daemon", path);
+		if (service_register(SVC_TYPE_SERVICE, cmd, global_rlimit, NULL)) {
+			_pe("Failed registering %s", path);
+		} else {
+			snprintf(cmd, sizeof(cmd), ":1 [S] <svc%s> "
+				 "udevadm trigger -c add -t devices "
+				 "-- Requesting device events", path);
+			service_register(SVC_TYPE_RUN, cmd, global_rlimit, NULL);
+
+			snprintf(cmd, sizeof(cmd), ":2 [S] <svc%s> "
+				 "udevadm trigger -c add -t subsystems "
+				 "-- Requesting subsystem events", path);
+			service_register(SVC_TYPE_RUN, cmd, global_rlimit, NULL);
+		}
+
+		free(path);
+
+		/* Debian has this little script to copy generated
+		 * rules while the system was read-only. TODO: When
+		 * this functionality was hardcoded in finit.c, this
+		 * call was made in crank_worker(). Now that
+		 * filesystems are mounted earlier we should be able
+		 * to make this call directly after the triggers have
+		 * run, but this has not been tested AT ALL. */
+		if (fexist("/lib/udev/udev-finish"))
+			run_interactive("/lib/udev/udev-finish", "Finalizing udev");
+	} else {
+		path = which("mdev");
+		if (path) {
+			/* Embedded Linux systems usually have BusyBox mdev */
+			if (log_is_debug())
+				touch("/dev/mdev.log");
+
+			snprintf(cmd, sizeof(cmd), "%s -s", path);
+			free(path);
+
+			run_interactive(cmd, "Populating device tree");
+		}
+	}
+}
+
+static plugin_t plugin = {
+	.name = __FILE__,
+	.hook[HOOK_BASEFS_UP] = {
+		.cb  = setup
+	},
+};
+
+PLUGIN_INIT(plugin_init)
+{
+	plugin_register(&plugin);
+}
+
+PLUGIN_EXIT(plugin_exit)
+{
+	plugin_unregister(&plugin);
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/src/conf.c
+++ b/src/conf.c
@@ -59,6 +59,22 @@ static TAILQ_HEAD(head, conf_change) conf_change_list = TAILQ_HEAD_INITIALIZER(c
 static int parse_conf(char *file);
 static void drop_changes(void);
 
+static void hide_args(int argc, char *argv[])
+{
+	/*
+	 * Hide command line arguments from ps (in particular for
+	 * forked children that don't execv()).  This is an ugly
+	 * hack that only works on Linux.
+	 * https://web.archive.org/web/20110227041321/http://netsplit.com/2007/01/10/hiding-arguments-from-ps/
+	 */
+	if (argc > 1) {
+		char *arg_end;
+
+		arg_end = argv[argc-1] + strlen (argv[argc-1]);
+		*arg_end = ' ';
+	}
+}
+
 static void parse_arg(char *arg, int *dbg)
 {
 	/* Catches finit_debug (deprecated), --debug, and debug */
@@ -83,6 +99,8 @@ void conf_parse_cmdline(int argc, char *argv[])
 
 	for (int i = 1; i < argc; i++)
 		parse_arg(argv[i], &dbg);
+
+	hide_args(argc, argv);
 
 	fp = fopen("/proc/cmdline", "r");
 	if (!fp)

--- a/src/finit.c
+++ b/src/finit.c
@@ -74,10 +74,7 @@ static int udev = 0;		/* Runtime detection of udev */
  */
 static void banner(void)
 {
-	if (plugin_exists(HOOK_BANNER)) {
-		plugin_run_hooks(HOOK_BANNER);
-		return;
-	}
+	plugin_run_hooks(HOOK_BANNER);
 
 	if (log_is_silent())
 		return;

--- a/src/finit.c
+++ b/src/finit.c
@@ -88,16 +88,12 @@ static void banner(void)
 static int fsck(int pass)
 {
 	struct fstab *fs;
-//	int save;
 	int rc = 0;
 
 	if (!setfsent()) {
 		_pe("Failed opening fstab");
 		return 1;
 	}
-
-//	if ((save = log_is_debug()))
-//		log_debug();
 
 	while ((fs = getfsent())) {
 		char cmd[80];
@@ -123,8 +119,6 @@ static int fsck(int pass)
 		rc += run_interactive(cmd, "Checking filesystem %.13s", fs->fs_spec);
 	}
 
-//	if (save)
-//		log_debug();
 	endfsent();
 
 	return rc;

--- a/src/finit.c
+++ b/src/finit.c
@@ -299,19 +299,6 @@ int main(int argc, char *argv[])
 	conf_parse_cmdline(argc, argv);
 
 	/*
-	 * Hide command line arguments from ps (in particular for
-	 * forked children that don't execv()).  This is an ugly
-	 * hack that only works on Linux.
-	 * https://web.archive.org/web/20110227041321/http://netsplit.com/2007/01/10/hiding-arguments-from-ps/
-	 */
-	if (argc > 1) {
-		char *arg_end;
-
-		arg_end = argv[argc-1] + strlen (argv[argc-1]);
-		*arg_end = ' ';
-	}
-
-	/*
 	 * Initalize event context.
 	 */
 	uev_init1(&loop, 1);

--- a/src/finit.c
+++ b/src/finit.c
@@ -378,6 +378,10 @@ int main(int argc, char *argv[])
 	 */
 	emergency_shell();
 
+	/* Load plugins early, the first hook is in banner(), so we
+	 * need plugins loaded before calling it. */
+	plugin_init(&loop);
+
 	/*
 	 * Hello world.
 	 */
@@ -387,12 +391,6 @@ int main(int argc, char *argv[])
 	 * Initial setup of signals, ignore all until we're up.
 	 */
 	sig_init();
-
-	/*
-	 * Load plugins early, finit.conf may contain references to
-	 * features implemented by plugins.
-	 */
-	plugin_init(&loop);
 
 	/*
 	 * Initialize default control groups, if available

--- a/src/finit.c
+++ b/src/finit.c
@@ -399,12 +399,14 @@ int main(int argc, char *argv[])
 	 */
 	cgroup_init();
 
+
+	/* Check and mount filesystems. */
+	fs_init();
+
 	/*
 	 * Initialize .conf system and load static /etc/finit.conf.
 	 */
 	conf_init();
-
-	fs_init();
 
 	/* Bootstrap conditions, needed for hooks */
 	cond_init();

--- a/src/finit.c
+++ b/src/finit.c
@@ -417,10 +417,8 @@ int main(int argc, char *argv[])
 	/* Base FS up, enable standard SysV init signals */
 	sig_setup(&loop);
 
-	if (!rescue) {
-		_d("Base FS up, calling hooks ...");
-		plugin_run_hooks(HOOK_BASEFS_UP);
-	}
+	_d("Base FS up, calling hooks ...");
+	plugin_run_hooks(HOOK_BASEFS_UP);
 
 	/*
 	 * Set up inotify watcher for /etc/finit.d and read all .conf

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -201,7 +201,12 @@ void plugin_run_hook(hook_point_t no, void *arg)
 		}
 	}
 
-	cond_set_oneshot(hook_cond[no]);
+	/* Conditions are stored in /run, so don't try to signal
+	 * conditions for any hooks before filesystems have been
+	 * mounted. */
+	if (no >= HOOK_MOUNT_ERROR)
+		cond_set_oneshot(hook_cond[no]);
+
 	service_step_all(SVC_TYPE_RUNTASK);
 }
 


### PR DESCRIPTION
This series refactors the core of Finit with the goal of giving the user more ability to tailor the system to their liking. As a result, it cuts many lines from `main()`, making it easier to get an overview of the boot process. The big stuff:

- Generic cleanup/moving around of dead/misplaced code.

- Remove all automatic mounting of different filesystems at different points in the boot process; just call out to `mount -na` and let the user decide on the exact set of filesystems and options.

- Move `udev`/`mdev` stuff out to a plugin that can be disabled and replaced with whatever the user needs (or doesn't need).

I would really like some feedback on the series as it is now, so that we can integrate these changes before going further.