### PR TITLE
Handle SIGPWR like SIGUSR2

### DIFF
--- a/src/sig.c
+++ b/src/sig.c
@@ -517,11 +517,11 @@ void sig_setup(uev_ctx_t *ctx)
 
 	/* Standard SysV init calls ctrl-alt-delete handler */
 	uev_signal_init(ctx, &sigint_watcher, sigint_cb, NULL, SIGINT);
-	uev_signal_init(ctx, &sigpwr_watcher, sigint_cb, NULL, SIGPWR);
 
 	/* BusyBox init style signals for halt, power-off and reboot. */
 	uev_signal_init(ctx, &sigusr1_watcher, sigusr1_cb, NULL, SIGUSR1);
 	uev_signal_init(ctx, &sigusr2_watcher, sigusr2_cb, NULL, SIGUSR2);
+	uev_signal_init(ctx, &sigpwr_watcher, sigusr2_cb, NULL, SIGPWR);
 	uev_signal_init(ctx, &sigterm_watcher, sigterm_cb, NULL, SIGTERM);
 
 	/* Some C APIs may need SIGALRM for implementing timers. */


### PR DESCRIPTION
This seems to be inline with Busybox init, SysV init and, according
to the comments in code, the intended behaviour of Finit.

The effect is that `SIGPWR` will lead to Finit issuing the syscall `reboot`
with `cmd` parameter set to `RB_POWER_OFF` (rather than `RB_AUTOBOOT`), which
in turn will lead to a halt rather than a reboot.
The effect of the above inside a PID namespace other than the initial PID
namespace is that `wait` inside the parent of Finit will report that Finit was
killed with a `SIGINT` signal rather than `SIGHUP`.