### PR TITLE
Fix #139: System timezone changes does not 'take' in Finit

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -29,7 +29,7 @@
 #include <sys/resource.h>
 #include <lite/lite.h>
 #include <lite/queue.h>		/* BSD sys/queue.h API */
-#include <sys/time.h>
+#include <time.h>
 #include <glob.h>
 
 #include "finit.h"
@@ -645,6 +645,11 @@ int conf_reload(void)
 {
 	size_t i;
 	glob_t gl;
+
+	/* Set time according to current time zone */
+	tzset();
+	_d("Set time  daylight: %d  timezone: %ld  tzname: %s %s",
+	   daylight, timezone, tzname[0], tzname[1]);
 
 	/* Mark and sweep */
 	svc_mark_dynamic();


### PR DESCRIPTION
The tzset() function sets the global variables 'daylight', 'timezone' and 'tzname'
according to the value of the TZ environment variable, or to the value of the
_CS_TIMEZONE configuration string if TZ isn't set, or to UTC0 if neither is set.