### PR TITLE
Store removal status separate from dirty

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1175,6 +1175,8 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
 	else
 		svc_mark_clean(svc);
 
+	svc_enable(svc);
+
 	/* for finit native services only, e.g. plugins/hotplug.c */
 	if (!file)
 		svc->protect = 1;

--- a/src/svc.c
+++ b/src/svc.c
@@ -458,7 +458,7 @@ void svc_mark_dynamic(void)
 		if (svc->protect)
 			continue;
 
-		*((int *)&svc->dirty) = -1;
+		*((int *)&svc->removed) = 1;
 	}
 }
 
@@ -470,6 +470,11 @@ void svc_mark_dirty(svc_t *svc)
 void svc_mark_clean(svc_t *svc)
 {
 	*((int *)&svc->dirty) = 0;
+}
+
+void svc_enable(svc_t *svc)
+{
+	*((int *)&svc->removed) = 0;
 }
 
 /**
@@ -484,7 +489,7 @@ void svc_clean_dynamic(void (*cb)(svc_t *))
 	svc_t *svc, *iter = NULL;
 
 	for (svc = svc_iterator(&iter, 1); svc; svc = svc_iterator(&iter, 0)) {
-		if (svc->dirty == -1 && cb)
+		if (svc->removed && cb)
 			cb(svc);
 	}
 }

--- a/src/svc.h
+++ b/src/svc.h
@@ -106,7 +106,8 @@ typedef struct svc {
 	const svc_state_t state;       /* Paused, Reloading, Restart, Running, ... */
 	svc_type_t     type;	       /* Service, run, task, ... */
 	int            protect;        /* Services like dbus-daemon & udev by Finit */
-	const int      dirty;	       /* -1: removal, 0: unmodified, 1: modified */
+	const int      dirty;	       /* 0: unmodified, 1: modified */
+	const int      removed;
 	int            starting;       /* ... waiting for pidfile to be re-asserted */
 	int	       runlevels;
 	int            sighup;	       /* This service supports SIGHUP :) */
@@ -179,6 +180,7 @@ void	    svc_clean_dynamic      (void (*cb)(svc_t *));
 int	    svc_clean_bootstrap    (svc_t *svc);
 void	    svc_prune_bootstrap	   (void);
 
+void        svc_enable             (svc_t *svc);
 int         svc_enabled            (svc_t *svc);
 int         svc_is_unique          (svc_t *svc);
 
@@ -197,7 +199,7 @@ static inline void svc_starting    (svc_t *svc) { if (svc) svc->starting = 1;   
 static inline void svc_started     (svc_t *svc) { if (svc) svc->starting = 0;       }
 static inline int  svc_is_starting (svc_t *svc) { return svc && 0 != svc->starting; }
 
-static inline int  svc_is_removed  (svc_t *svc) { return svc && -1 == svc->dirty; }
+static inline int  svc_is_removed  (svc_t *svc) { return svc && svc->removed; }
 static inline int  svc_is_changed  (svc_t *svc) { return svc &&  0 != svc->dirty; }
 static inline int  svc_is_updated  (svc_t *svc) { return svc &&  1 == svc->dirty; }
 


### PR DESCRIPTION
Having removal status stored in the dirty status resulted in removal
status being forgotten when a service was marked as dirty, for instance
when a dependency was updated. This side effect of marke_dirty seems a bit
unexpected and instead of adding exceptions to the logic for when marking
a service dirty - let's separate the two things (dirty and removed) from each
other.

Signed-off-by: Jacques de Laval <Jacques.De.Laval@westermo.com>