### PR TITLE
Do a full restart rather than HUP if command line of a service has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,11 @@ For more information, see [doc/plugins.md](doc/plugins.md).
 By default, Finit monitors `/etc/finit.d/` and `/etc/finit.d/enabled/`
 registering any changes to `.conf` files.  To activate a change the user
 must call `initctl reload`, which reloads all modified files, stops any
-removed services, starts new ones, and restarts any modified ones, with
-SIGHUP if the process supports it.
+removed services, starts new ones, and restarts any modified ones.  If the
+command line arguments of a service have changed, the process will be
+terminated and then started again with the updated arguments. If the arguments
+have not been modified and the process supports SIGHUP, the process will
+receive a SIGHUP rather than being terminated and started.
 
 For some use-cases the extra step of calling `initctl reload` creates an
 unnecessary overhead, which can be removed at build-time using:

--- a/src/svc.c
+++ b/src/svc.c
@@ -498,6 +498,7 @@ void svc_mark_dirty(svc_t *svc)
 void svc_mark_clean(svc_t *svc)
 {
 	*((int *)&svc->dirty) = 0;
+	*((int *)&svc->args_dirty) = 0;
 }
 
 void svc_enable(svc_t *svc)

--- a/src/svc.h
+++ b/src/svc.h
@@ -142,6 +142,7 @@ typedef struct svc {
 	/* Command, arguments and service description */
 	char	       cmd[MAX_ARG_LEN];
 	char	       args[MAX_NUM_SVC_ARGS][MAX_ARG_LEN];
+	int            args_dirty;
 	char	       desc[MAX_STR_LEN];
 	char	       env[MAX_ARG_LEN];
 
@@ -194,7 +195,7 @@ static inline int svc_is_runtask   (svc_t *svc) { return svc && (SVC_TYPE_RUNTAS
 static inline int svc_is_forking   (svc_t *svc) { return (svc_is_daemon(svc) || svc_is_sysv(svc)) && svc->pidfile[0] == '!'; }
 
 static inline int svc_in_runlevel  (svc_t *svc, int runlevel) { return svc && ISSET(svc->runlevels, runlevel); }
-static inline int svc_has_sighup   (svc_t *svc) { return svc &&  0 != svc->sighup; }
+static inline int svc_nohup        (svc_t *svc) { return svc &&  (0 == svc->sighup || 0 != svc->args_dirty); }
 static inline int svc_has_pidfile  (svc_t *svc) { return svc_is_daemon(svc) && svc->pidfile[0] != 0 && svc->pidfile[0] != '!'; }
 
 static inline void svc_starting    (svc_t *svc) { if (svc) svc->starting = 1;       }


### PR DESCRIPTION
By keeping track of when a full restart is needed, Finit can relieve
the user of having to track modifications to service configuration. This
also makes initctl reload easier to explain and reason about as the effect
of a reload should now be that any configuration updates to services will
be fully "commited" by initctl reload.