### PR TITLE
Tty refactor

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -19,9 +19,6 @@ Some of these are also registered in the issue tracker on GitHub.
 * Add new (complimentary) .svc file format to slowly migrate away
   from the very terse one-liner format currently used
 * Allow running as non-pid1 => read .conf and RCSD form cmdline
-* When a process dies, and Finit does not restart it, we should collect
-  a `siginfo_t` from the SIGCHLD signal and supply to the user in case
-  `initctl status <process>` is called to debug the issue.
 * Add `finit.conf` support for UPS notification (SIGPWR) to start a task
   using, e.g. <sys/power/{ok,fail,low}> conditions.  More info in sig.c
 * Add `finit.conf` support for ctrl-alt-delete (SIGINT) and kbrequest,

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -26,7 +26,10 @@ Some of these are also registered in the issue tracker on GitHub.
   e.g, <sys/key/ctrlaltdel> and <sys/key/signal> like SIGPWR handling.
 * Write man pages for finit and `finit.conf`, steal from the excellent
   `pimd` man pages ...
-* Add support for timed shutdown in Finit, including cancelled shutdown
+* Add support for timed shutdown in Finit, including cancelled shutdown:
+
+        shutdown -h 03:35 "foobar was here"
+
 * Add support for JSON output, or similar, from `initctl show`, e.g.
   `initctl show --json`
 

--- a/plugins/tty.c
+++ b/plugins/tty.c
@@ -55,17 +55,19 @@ static void setup(void)
 
 static void do_tty(char *tty, size_t len, int creat)
 {
+#if 0
 	char name[len + 6];
-	struct tty *entry;
+	svc_t *entry;
 
 	snprintf(name, sizeof(name), "/dev/%s", tty);
-	entry = tty_find(name);
+	entry = svc_find_by_tty(name);
 	if (entry && tty_enabled(entry)) {
 		if (creat)
 			tty_start(entry);
 		else if (entry->pid)
 			tty_stop(entry);
 	}
+#endif
 }
 
 static void watcher(void *arg, int fd, int events)

--- a/src/cond-w.c
+++ b/src/cond-w.c
@@ -127,12 +127,12 @@ static int cond_checkpath(const char *path)
 	return 0;
 }
 
-int cond_set_path(const char *path, enum cond_state new)
+int cond_set_path(const char *path, enum cond_state next)
 {
-	enum cond_state old;
+	enum cond_state prev;
 	unsigned int rgen;
 
-	_d("%s", path);
+	_d("%s <= %d", path, next);
 
 	rgen = cond_get_gen(_PATH_RECONF);
 	if (!rgen) {
@@ -140,9 +140,9 @@ int cond_set_path(const char *path, enum cond_state new)
 		return -1;
 	}
 
-	old = cond_get_path(path);
+	prev = cond_get_path(path);
 
-	switch (new) {
+	switch (next) {
 	case COND_ON:
 		if (cond_checkpath(path))
 		    return 0;
@@ -159,7 +159,7 @@ int cond_set_path(const char *path, enum cond_state new)
 		return 0;
 	}
 
-	return new != old;
+	return next != prev;
 }
 
 /* Should only be used by cond_set*(), cond_clear(), and usr plugin! */

--- a/src/conf.c
+++ b/src/conf.c
@@ -737,6 +737,10 @@ int conf_reload(void)
 
 	globfree(&gl);
 
+	/* Verify config, do we have at least one TTY available? */
+	if (tty_fallback(FINIT_CONF))
+		logit(LOG_WARNING, "warning, no getty enabled on local TTYs.");
+
 	/* Mark any reverse deps as chenaged. */
 	service_update_rdeps();
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -592,7 +592,7 @@ static void parse_dynamic(char *line, struct rlimit rlimit[], char *file)
 
 	/* Regular or serial TTYs to run getty */
 	if (MATCH_CMD(line, "tty ", x)) {
-		tty_register(strip_line(x), rlimit, file);
+		service_register(SVC_TYPE_TTY, strip_line(x), rlimit, file);
 		return;
 	}
 }
@@ -664,7 +664,6 @@ int conf_reload(void)
 	/* Mark and sweep */
 	cgroup_mark_all();
 	svc_mark_dynamic();
-	tty_mark();
 
 	/*
 	 * Reset global rlimit to bootstrap values from conf_init().
@@ -678,7 +677,7 @@ int conf_reload(void)
 		/* If rescue.conf is missing, fall back to a root shell */
 		rc = parse_conf(RESCUE_CONF, 0);
 		if (rc)
-			tty_register(line, global_rlimit, NULL);
+			service_register(SVC_TYPE_TTY, line, global_rlimit, NULL);
 
 		print(rc, "Entering rescue mode");
 		goto done;

--- a/src/exec.c
+++ b/src/exec.c
@@ -418,7 +418,7 @@ pid_t run_sh(char *tty, int noclear, int nowait, struct rlimit rlimit[])
 {
 	int rc = 1;
 
-	prepare_tty(tty, B0, "finit-sh", rlimit);
+	prepare_tty(tty, B0, "finitsh", rlimit);
 	if (activate_console(noclear, nowait))
 		rc = sh(tty);
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -405,7 +405,7 @@ pid_t run_getty2(char *tty, char *cmd, char *args[], int noclear, int nowait, st
 	/* Dunno speed, tell stty() to not mess with it */
 	prepare_tty(tty, B0, "getty", rlimit);
 	if (activate_console(noclear, nowait)) {
-		logit(LOG_INFO, "Starting external getty on %s, speed %u", tty, B0);
+		logit(LOG_INFO, "Starting external getty on %s", tty);
 		rc = execv(cmd, args);
 	}
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -245,10 +245,6 @@ static void prepare_tty(char *tty, speed_t speed, char *procname, struct rlimit 
 	char name[80];
 	int fd;
 
-	/* Detach from initial controlling TTY and become session leader */
-	vhangup();
-	setsid();
-
 	fd = open(tty, O_RDWR);
 	if (fd < 0) {
 		logit(LOG_ERR, "Failed opening %s: %s", tty, strerror(errno));
@@ -260,6 +256,11 @@ static void prepare_tty(char *tty, speed_t speed, char *procname, struct rlimit 
 	dup2(fd, STDERR_FILENO);
 	close(fd);
 
+	/*
+	 * Become session leader and set controlling TTY
+	 * to enable Ctrl-C and job control in shell.
+	 */
+	setsid();
 	if (ioctl(STDIN_FILENO, TIOCSCTTY, 1) < 0)
 		logit(LOG_WARNING, "Failed TIOCSCTTY on %s: %s", tty, strerror(errno));
 

--- a/src/finit.c
+++ b/src/finit.c
@@ -59,6 +59,7 @@ int   prevlevel = -1;
 int   debug     = 0;		/* debug mode from kernel cmdline */
 int   rescue    = 0;		/* rescue mode from kernel cmdline */
 int   single    = 0;		/* single user mode from kernel cmdline */
+int   bootstrap = 1;		/* set while bootrapping (for TTYs) */
 char *sdown     = NULL;
 char *network   = NULL;
 char *hostname  = NULL;
@@ -310,9 +311,9 @@ static void finalize(void *unused)
 	/* Disable progress output at normal runtime */
 	enable_progress(0);
 
-	/* Delayed start of TTYs at bootstrap */
-	_d("Launching all getty services ...");
-	tty_runlevel();
+	/* System bootrapped, launch TTYs et al */
+	bootstrap = 0;
+	service_step_all(SVC_TYPE_RESPAWN);
 }
 
 /*

--- a/src/finit.h
+++ b/src/finit.h
@@ -30,6 +30,7 @@
 #include <paths.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sysexits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -105,6 +106,7 @@ extern int    prevlevel;
 extern int    debug;
 extern int    rescue;
 extern int    single;
+extern int    bootstrap;
 extern char  *rcsd;
 extern char  *sdown;
 extern char  *network;

--- a/src/initctl.c
+++ b/src/initctl.c
@@ -626,7 +626,7 @@ static char *status(svc_t *svc, int full)
 {
 	static char buf[64];
 	const char *color;
-	char ok[64] = {0};
+	char ok[32] = {0};
 	char *s;
 
 	s = svc_status(svc);

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -196,7 +196,7 @@ void plugin_run_hook(hook_point_t no, void *arg)
 
 	PLUGIN_ITERATOR(p, tmp) {
 		if (p->hook[no].cb) {
-			_d("Calling %s hook n:o %d (arg: %p) ...", basename(p->name), no, arg);
+			_d("Calling %s hook n:o %d (arg: %p) ...", basename(p->name), no, arg ?: "NIL");
 			p->hook[no].cb(arg ? arg : p->hook[no].arg);
 		}
 	}

--- a/src/service.c
+++ b/src/service.c
@@ -654,6 +654,9 @@ static void service_cleanup(svc_t *svc)
 		logit(LOG_CRIT, "Failed removing service %s pidfile %s",
 		      basename(svc->cmd), fn);
 
+	/* PID collected, cancel any pending SIGKILL */
+	service_timeout_cancel(svc);
+
 	/* No longer running, update books. */
 	if (svc_is_tty(svc) && svc->pid > 1)
 		utmp_set_dead(svc->pid); /* Set DEAD_PROCESS UTMP entry */

--- a/src/service.c
+++ b/src/service.c
@@ -702,7 +702,7 @@ static int service_stop(svc_t *svc)
 		if (svc->pid > 1) {
 			/* Kill all children in the same proess group, e.g. logit */
 			rc = kill(-svc->pid, svc->sighalt);
-
+			_d("kill(-%d, %d) => rc %d", svc->pid, svc->sighalt, rc);
 			/* PID lost or forking process never really started */
 			if (rc == -1 && ESRCH == errno)
 				service_cleanup(svc);

--- a/src/service.c
+++ b/src/service.c
@@ -962,7 +962,7 @@ static void parse_cmdline_args(svc_t *svc, char *cmd)
 	 * Copy supplied args. Stop at MAX_NUM_SVC_ARGS-1 to allow the args
 	 * array to be zero-terminated.
 	 */
-	for (i = 1; (arg = strtok(NULL, " ")) && i < (MAX_NUM_SVC_ARGS - 1);) {
+	while ((arg = strtok(NULL, " ")) && i < (MAX_NUM_SVC_ARGS - 1)) {
 		char prev[sizeof(svc->args[0])] = { 0 };
 		char ch = arg[0];
 		size_t len;
@@ -1005,13 +1005,6 @@ static void parse_cmdline_args(svc_t *svc, char *cmd)
 			diff++;
 		}
 	}
-#if 0
-	for (i = 0; i < MAX_NUM_SVC_ARGS; i++) {
-		if (!svc->args[i][0])
-			break;
-		_d("%s ", svc->args[i]);
-	}
-#endif
 
 	if (diff)
 		_d("Modified args for %s detected", cmd);
@@ -1417,7 +1410,8 @@ static void service_retry(svc_t *svc)
 
 	if (svc->state != SVC_HALTED_STATE ||
 	    svc->block != SVC_BLOCK_RESTARTING) {
-		_d("%s not crashing anymore", svc->cmd);
+		if (!svc_is_tty(svc))
+			_d("%s not crashing anymore", svc->cmd);
 		*restart_cnt = 0;
 		return;
 	}

--- a/src/service.c
+++ b/src/service.c
@@ -412,6 +412,16 @@ static int service_start(svc_t *svc)
 		return 1;
 	}
 
+	if (svc_is_tty(svc)) {
+		char *dev = tty_canonicalize(svc->dev);
+
+		if (!dev || !tty_exists(dev)) {
+			_d("TTY %s missing or invalid, halting service.", svc->dev);
+			svc_missing(svc);
+			return 1;
+		}
+	}
+
 	if (svc_is_sysv(svc))
 		logit(LOG_CONSOLE | LOG_NOTICE, "Calling '%s start' ...", svc->cmd);
 

--- a/src/service.c
+++ b/src/service.c
@@ -1248,6 +1248,7 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
 		svc->noclear = tty.noclear;
 		svc->nowait  = tty.nowait;
 		svc->nologin = tty.nologin;
+		svc->notty   = tty.notty;
 
 		/* TTYs cannot be redirected */
 		log = NULL;

--- a/src/sm.c
+++ b/src/sm.c
@@ -206,10 +206,6 @@ restart:
 			break;
 		}
 
-		/* No TTYs run at bootstrap, they have a delayed start. */
-		if (prevlevel > 0)
-			tty_runlevel();
-
 		sm->state = SM_RUNNING_STATE;
 		break;
 
@@ -224,8 +220,7 @@ restart:
 		_d("Stopping services not allowed after reconf ...");
 		sm->in_teardown = 1;
 		cond_reload();
-		service_step_all(SVC_TYPE_SERVICE);
-		tty_reload(NULL);
+		service_step_all(SVC_TYPE_ANY);
 
 		sm->state = SM_RELOAD_WAIT_STATE;
 		break;
@@ -242,16 +237,17 @@ restart:
 		}
 
 		sm->in_teardown = 0;
-		/* Cleanup stale services */
-		svc_clean_dynamic(service_unregister);
 
 		_d("Starting services after reconf ...");
-		service_step_all(SVC_TYPE_SERVICE);
+		service_step_all(SVC_TYPE_ANY);
+
+		/* Cleanup stale services */
+		svc_clean_dynamic(service_unregister);
 
 		_d("Calling reconf hooks ...");
 		plugin_run_hooks(HOOK_SVC_RECONF);
 
-		service_step_all(SVC_TYPE_SERVICE);
+		service_step_all(SVC_TYPE_ANY);
 		_d("Reconfiguration done");
 
 		sm->state = SM_RUNNING_STATE;

--- a/src/svc.c
+++ b/src/svc.c
@@ -441,7 +441,7 @@ svc_t *svc_find_by_tty(char *dev)
 		if (!svc_is_tty(svc))
 			continue;
 
-		if (!strcmp(dev, svc->name))
+		if (!strcmp(dev, svc->dev))
 			return svc;
 	}
 

--- a/src/svc.c
+++ b/src/svc.c
@@ -431,6 +431,10 @@ svc_t *svc_find_by_tty(char *dev)
 {
 	svc_t *svc, *iter = NULL;
 
+	/* this is valid for fallback shells */
+	if (!dev)
+		return NULL;
+
 	for (svc = svc_iterator(&iter, 1); svc; svc = svc_iterator(&iter, 0)) {
 		if (!svc_is_tty(svc))
 			continue;

--- a/src/svc.c
+++ b/src/svc.c
@@ -192,6 +192,8 @@ void svc_validate(svc_t *svc)
 	for (s = svc_iterator(&iter, 1); s; s = svc_iterator(&iter, 0)) {
 		char c[MAX_COND_LEN];
 
+		if (s->removed)
+			continue;
 		if (s == svc)
 			continue;
 

--- a/src/svc.c
+++ b/src/svc.c
@@ -114,7 +114,7 @@ svc_t *svc_new(char *cmd, char *id, int type)
 
 	/* Find first job n:o if registering multiple instances */
 	for (svc = svc_iterator(&iter, 1); svc; svc = svc_iterator(&iter, 0)) {
-		if (!strcmp(svc->cmd, cmd)) {
+		if (cmd && !strcmp(svc->cmd, cmd)) {
 			job = svc->job;
 			break;
 		}
@@ -130,13 +130,17 @@ svc_t *svc_new(char *cmd, char *id, int type)
 	svc->job  = job;
 	if (id && id[0])
 		strlcpy(svc->id, id, sizeof(svc->id));
-	strlcpy(svc->cmd, cmd, sizeof(svc->cmd));
+	if (cmd)
+		strlcpy(svc->cmd, cmd, sizeof(svc->cmd));
 
 	/* Default description, if missing */
 	strlcpy(svc->desc, svc->name, sizeof(svc->desc));
 
 	/* Default HALT signal to send */
-	svc->sighalt = SIGTERM;
+	if (svc_is_tty(svc))
+		svc->sighalt = SIGHUP;
+	else
+		svc->sighalt = SIGTERM;
 
 	/* Default delay between SIGTERM and SIGKILL */
 	svc->killdelay = SVC_TERM_TIMEOUT;
@@ -327,7 +331,7 @@ svc_t *svc_stop_completed(void)
 	svc_t *svc, *iter = NULL;
 
 	for (svc = svc_iterator(&iter, 1); svc; svc = svc_iterator(&iter, 0)) {
-		if (svc->state == SVC_STOPPING_STATE)
+		if (svc->state == SVC_STOPPING_STATE && svc->pid > 1)
 			return svc;
 	}
 
@@ -416,6 +420,22 @@ svc_t *svc_find_by_nameid(char *name, char *id)
 
 	for (svc = svc_iterator(&iter, 1); svc; svc = svc_iterator(&iter, 0)) {
 		if (!strcmp(svc->id, id) && !strcmp(name, svc->name))
+			return svc;
+	}
+
+	return NULL;
+}
+
+
+svc_t *svc_find_by_tty(char *dev)
+{
+	svc_t *svc, *iter = NULL;
+
+	for (svc = svc_iterator(&iter, 1); svc; svc = svc_iterator(&iter, 0)) {
+		if (!svc_is_tty(svc))
+			continue;
+
+		if (!strcmp(dev, svc->name))
 			return svc;
 	}
 
@@ -579,6 +599,9 @@ int svc_enabled(svc_t *svc)
 		return 0;
 
 	if (svc_is_missing(svc))
+		return 0;
+
+	if (svc_is_tty(svc) && bootstrap)
 		return 0;
 
 	return 1;

--- a/src/svc.h
+++ b/src/svc.h
@@ -143,9 +143,10 @@ typedef struct svc {
 			char  dev[32];
 			char  baud[10];
 			char  term[10];
-			int   noclear;
-			int   nowait;
-			int   nologin;
+			char  noclear;
+			char  nowait;
+			char  nologin;
+			char  notty;
 		};
 	};
 

--- a/src/svc.h
+++ b/src/svc.h
@@ -42,10 +42,12 @@ typedef enum {
 	SVC_TYPE_SERVICE    = 1,	/* Monitored, will be respawned */
 	SVC_TYPE_TASK       = 2,	/* One-shot, runs in parallell */
 	SVC_TYPE_RUN        = 4,	/* Like task, but wait for completion */
+	SVC_TYPE_TTY        = 8,	/* Like service, but dedicated to TTYs */
 	SVC_TYPE_SYSV       = 32,	/* SysV style init.d script w/ start/stop */
 } svc_type_t;
 
 #define SVC_TYPE_ANY          (-1)
+#define SVC_TYPE_RESPAWN      (SVC_TYPE_SERVICE | SVC_TYPE_TTY)
 #define SVC_TYPE_RUNTASK      (SVC_TYPE_RUN | SVC_TYPE_TASK | SVC_TYPE_SYSV)
 
 typedef enum {
@@ -125,15 +127,27 @@ typedef struct svc {
 	char           once;	       /* run/task, (at least) once per runlevel */
 	const char     restart_cnt;    /* Incremented for each restart by service monitor. */
 
-	/* Set for services we need to redirect stdout/stderr to syslog */
-	struct {
-		char   enabled;
-		char   null;
-		char   console;
-		char   file[64];
-		char   prio[20];
-		char   ident[20];
-	} log;
+	union {
+		/* services we redirect stdout/stderr to syslog (not TTYs!) */
+		struct {
+			char  enabled;
+			char  null;
+			char  console;
+			char  file[64];
+			char  prio[20];
+			char  ident[20];
+		} log;
+
+		/* Only for TTY type services */
+		struct {
+			char  dev[32];
+			char  baud[10];
+			char  term[10];
+			int   noclear;
+			int   nowait;
+			int   nologin;
+		};
+	};
 
 	/* Identity */
 	char	       username[MAX_USER_LEN];
@@ -165,6 +179,7 @@ svc_t	   *svc_find	           (char *cmd, char *id);
 svc_t	   *svc_find_by_pid        (pid_t pid);
 svc_t	   *svc_find_by_jobid      (int job, char *id);
 svc_t	   *svc_find_by_nameid     (char *name, char *id);
+svc_t	   *svc_find_by_tty        (char *dev);
 svc_t      *svc_find_by_pidfile    (char *fn);
 
 svc_t      *svc_iterator           (svc_t **iter, int first);
@@ -189,9 +204,10 @@ int         svc_is_unique          (svc_t *svc);
 
 int         svc_parse_jobstr       (char *str, size_t len, int (*found)(svc_t *), int (not_found)(char *, char *));
 
-static inline int svc_is_daemon    (svc_t *svc) { return svc && SVC_TYPE_SERVICE    == svc->type; }
-static inline int svc_is_sysv      (svc_t *svc) { return svc && SVC_TYPE_SYSV       == svc->type; }
-static inline int svc_is_runtask   (svc_t *svc) { return svc && (SVC_TYPE_RUNTASK & svc->type);   }
+static inline int svc_is_daemon    (svc_t *svc) { return svc && SVC_TYPE_SERVICE == svc->type; }
+static inline int svc_is_sysv      (svc_t *svc) { return svc && SVC_TYPE_SYSV    == svc->type; }
+static inline int svc_is_tty       (svc_t *svc) { return svc && SVC_TYPE_TTY     == svc->type; }
+static inline int svc_is_runtask   (svc_t *svc) { return svc && (SVC_TYPE_RUNTASK & svc->type);}
 static inline int svc_is_forking   (svc_t *svc) { return (svc_is_daemon(svc) || svc_is_sysv(svc)) && svc->pidfile[0] == '!'; }
 
 static inline int svc_in_runlevel  (svc_t *svc, int runlevel) { return svc && ISSET(svc->runlevels, runlevel); }
@@ -229,6 +245,7 @@ static inline int svc_has_cond(svc_t *svc)
 	case SVC_TYPE_SERVICE:
 	case SVC_TYPE_TASK:
 	case SVC_TYPE_RUN:
+	case SVC_TYPE_TTY:
 	case SVC_TYPE_SYSV:
 		return 1;
 

--- a/src/tty.c
+++ b/src/tty.c
@@ -191,7 +191,7 @@ int tty_parse_args(char *cmd, struct tty *tty)
 	}
 
 	_d("Registering %s getty on TTY %s at %s baud with term %s", tty->cmd ? "external" : "built-in",
-	   tty->dev, tty->baud ?: "NULL", tty->term ?: "N/A");
+	   tty->dev, tty->baud ?: "0", tty->term ?: "N/A");
 
 	return 0;
 }

--- a/src/tty.c
+++ b/src/tty.c
@@ -221,20 +221,20 @@ int tty_parse_args(char *cmd, struct tty *tty)
 	return 0;
 }
 
-static int tty_exist(char *dev)
+int tty_exists(char *dev)
 {
 	int fd, result;
 	struct termios c;
 
 	fd = open(dev, O_RDWR);
 	if (-1 == fd)
-		return 1;
+		return 0;
 
 	/* XXX: Add check for errno == EIO? */
 	result = tcgetattr(fd, &c);
 	close(fd);
 
-	return result;
+	return result == 0;
 }
 
 int tty_exec(svc_t *tty)
@@ -261,7 +261,7 @@ int tty_exec(svc_t *tty)
 		return EX_CONFIG;
 	}
 
-	if (tty_exist(dev)) {
+	if (!tty_exists(dev)) {
 		_d("%s: Not a valid TTY: %s", dev, strerror(errno));
 		return EX_OSFILE;
 	}

--- a/src/tty.h
+++ b/src/tty.h
@@ -49,6 +49,7 @@ char	*tty_atcon	  (void);
 
 int	 tty_parse_args   (char *cmdline, struct tty *tty);
 
+int	 tty_exists	  (char *dev);
 int	 tty_exec	  (svc_t *tty);
 int	 tty_fallback	  (char *file);
 

--- a/src/tty.h
+++ b/src/tty.h
@@ -36,9 +36,10 @@ struct tty {
 	char	*dev;
 	char	*baud;
 	char	*term;
-	int	 noclear;
-	int	 nowait;
-	int	 nologin;
+	char	 noclear;
+	char	 nowait;
+	char	 nologin;
+	char	 notty;
 };
 
 char	*tty_canonicalize (char *dev);
@@ -49,6 +50,7 @@ int	 tty_atcon        (char *buf, size_t len);
 int	 tty_parse_args   (char *cmdline, struct tty *tty);
 
 int	 tty_exec	  (svc_t *tty);
+int	 tty_fallback	  (char *file);
 
 #endif /* FINIT_TTY_H_ */
 

--- a/src/tty.h
+++ b/src/tty.h
@@ -45,7 +45,7 @@ struct tty {
 char	*tty_canonicalize (char *dev);
 
 int	 tty_isatcon      (char *dev);
-int	 tty_atcon        (char *buf, size_t len);
+char	*tty_atcon	  (void);
 
 int	 tty_parse_args   (char *cmdline, struct tty *tty);
 

--- a/src/tty.h
+++ b/src/tty.h
@@ -25,51 +25,30 @@
 #ifndef FINIT_TTY_H_
 #define FINIT_TTY_H_
 
-#include <limits.h>
-#include <sys/resource.h>
-#include <lite/queue.h>		/* BSD sys/queue.h API */
-
-#define TTY_MAX_ARGS 16
+#include <stdio.h>
+#include "svc.h"
 
 struct tty {
-	LIST_ENTRY(tty) link;
+	char	*cmd;
+	char	*args[MAX_NUM_SVC_ARGS];
+	size_t	 num;
 
-	char   name[42];
-	char   baud[10];
-	char   term[10];
-	int    noclear;
-	int    nowait;
-	int    nologin;
-	int    runlevels;
-
-	char  *cmd;		/* NULL when running built-in getty */
-	char  *args[TTY_MAX_ARGS];
-
-	int    pid;
-
-	/* Limits and scoping */
-	struct rlimit rlimit[RLIMIT_NLIMITS];
-
-	/* Set if modified => reloaded, or -1 when marked for removal */
-	int    dirty;
+	char	*dev;
+	char	*baud;
+	char	*term;
+	int	 noclear;
+	int	 nowait;
+	int	 nologin;
 };
 
-void	    tty_mark	    (void);
-void	    tty_sweep	    (void);
+char	*tty_canonicalize (char *dev);
 
-int	    tty_register    (char *line, struct rlimit rlimit[], char *file);
-int	    tty_unregister  (struct tty *tty);
+int	 tty_isatcon      (char *dev);
+int	 tty_atcon        (char *buf, size_t len);
 
-struct tty *tty_find	    (char *dev);
-size_t	    tty_num	    (void);
-size_t      tty_num_active  (void);
-struct tty *tty_find_by_pid (pid_t pid);
-void	    tty_start	    (struct tty *tty);
-void	    tty_stop	    (struct tty *tty);
-int	    tty_enabled	    (struct tty *tty);
-int	    tty_respawn	    (pid_t pid);
-void	    tty_reload      (char *dev);
-void	    tty_runlevel    (void);
+int	 tty_parse_args   (char *cmdline, struct tty *tty);
+
+int	 tty_exec	  (svc_t *tty);
 
 #endif /* FINIT_TTY_H_ */
 


### PR DESCRIPTION
This changeset is a refactor of the tty handling to use the same backend as service/run/task/sysv configuration directives.  Not only does it reduce the overall code required, simplifying and generalizing handling of all services, but it also adds functionality like conditions for ttys.

Closes #108 #65