### PR TITLE
logging: Disregard logging facility when comparing log levels

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -104,7 +104,7 @@ void logit(int prio, const char *fmt, ...)
 		goto done;
 	}
 
-	if (prio > loglevel)
+	if (LOG_PRI(prio) > loglevel)
 		goto done;
 
 	fp = fopen("/dev/kmsg", "w");


### PR DESCRIPTION
If we don't extract the level (disregarding facility), statements such as `logit(LOG_CONSOLE | LOG_NOTICE, ...)` would never reach the kernel log.