### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/conditions.md
+++ b/doc/conditions.md
@@ -180,7 +180,7 @@ PID     IDENT         STATUS  CONDITION (+ ON, ~ FLUX, - OFF)
 
 Here we can see that `netd` is allowed to run since both its conditions
 are in the `on` state, as indicated by the `+`-prefix.  `udhcpc` however
-is not allowed to run since `net/vlan1/exist` condition is not satsifed.
+is not allowed to run since `net/vlan1/exist` condition is not satisfied.
 As indicated by the `-`-prefix.
 
 To fake interface `vlan1` suddenly appearing, and test what happens to

--- a/src/mount.c
+++ b/src/mount.c
@@ -28,7 +28,7 @@
 /*
  * SysV init on Debian/Ubuntu skips these protected mount points
  *
- * It also skips anything below /proc, /sys and /run for good meausre so
+ * It also skips anything below /proc, /sys and /run for good measure so
  * we do the same here.  What we want is a list of non-protected tmpfs
  * and regular filesystems that can be safely unmounted before we do
  * swapoff, and remount / as read-only, respectively.

--- a/src/svc.h
+++ b/src/svc.h
@@ -102,7 +102,7 @@ typedef struct svc {
 	struct cgroup  cgroup;
 
 	/* Service details */
-	int            sighalt;        /* Signal to stop prorcess, default: SIGTERM */
+	int            sighalt;        /* Signal to stop process, default: SIGTERM */
 	int            killdelay;      /* Delay in msec before sending SIGKILL */
 	pid_t          oldpid, pid;
 	char           pidfile[256];


### PR DESCRIPTION
There are small typos in:
- doc/conditions.md
- src/mount.c
- src/svc.h

Fixes:
- Should read `satisfied` rather than `satsifed`.
- Should read `process` rather than `prorcess`.
- Should read `measure` rather than `meausre`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md