### PR TITLE
Avoid using C++ key words

### DIFF
--- a/src/cgroup.c
+++ b/src/cgroup.c
@@ -42,7 +42,7 @@ struct cg {
 	char *cfg;		/* kernel settings */
 
 	int  active;		/* for mark & sweep */
-	int  protected;		/* for init/, user/, & system/ */
+	int  is_protected;	/* for init/, user/, & system/ */
 };
 
 static TAILQ_HEAD(, cg) cgroups = TAILQ_HEAD_INITIALIZER(cgroups);
@@ -303,7 +303,7 @@ void cgroup_mark_all(void)
 	struct cg *cg;
 
 	TAILQ_FOREACH(cg, &cgroups, link) {
-		if (cg->protected)
+		if (cg->is_protected)
 			continue;
 
 		cg->active = 0;
@@ -330,7 +330,7 @@ void cgroup_cleanup(void)
 /*
  * Add, or update, settings for top-level cgroup
  */
-int cgroup_add(char *name, char *cfg, int protected)
+int cgroup_add(char *name, char *cfg, int is_protected)
 {
 	struct cg *cg;
 
@@ -364,7 +364,7 @@ int cgroup_add(char *name, char *cfg, int protected)
 		free(cg);
 		return -1;
 	}
-	cg->protected = protected;
+	cg->is_protected = is_protected;
 	cg->active = 1;
 
 	return 0;

--- a/src/cgroup.h
+++ b/src/cgroup.h
@@ -34,7 +34,7 @@ struct cgroup {
 void cgroup_mark_all(void);
 void cgroup_cleanup (void);
 
-int  cgroup_add     (char *name, char *cfg, int protected);
+int  cgroup_add     (char *name, char *cfg, int is_protected);
 int  cgroup_del     (char *dir);
 void cgroup_config  (void);
 

--- a/src/mount.c
+++ b/src/mount.c
@@ -36,7 +36,7 @@
 static int is_protected(char *dir)
 {
 	size_t i;
-	char *protected[] = {
+	char *protected_mnts[] = {
 		"/sys", "/proc",
 		"/.dev", "/dev", "/dev/pts", "/dev/shm", "dev/.static/dev", "/dev/vcs",
 		"/run", "/var/run",
@@ -46,8 +46,8 @@ static int is_protected(char *dir)
 		"/proc/", "/sys/", "/run/", NULL
 	};
 
-	for (i = 0; protected[i]; i++) {
-		if (!strcmp(dir, protected[i]))
+	for (i = 0; protected_mnts[i]; i++) {
+		if (!strcmp(dir, protected_mnts[i]))
 			return 1;
 	}
 


### PR DESCRIPTION
"protected" is a C++ key word, replace it with "is_protected" avoid
compiling failures with C++ compiler.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>