### PR TITLE
Introduce two more configure options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,14 @@ AC_ARG_ENABLE(kernel_cmdline,
         AS_HELP_STRING([--enable-kernel-cmdline], [Parse init args from /proc/cmdline (don't use!)]),,[
 	enable_kernel_cmdline=no])
 
+AC_ARG_ENABLE(fastboot,
+        AS_HELP_STRING([--enable-fastboot], [Skip fsck check on filesystems listed in /etc/fstab]),,[
+	enable_fastboot=no])
+
+AC_ARG_ENABLE(fsckfix,
+        AS_HELP_STRING([--enable-fsckfix], [Run fsck fix mode (options: -yf) on filesystems listed in /etc/fstab]),,[
+	enable_fsckfix=no])
+
 AC_ARG_ENABLE(redirect,
         AS_HELP_STRING([--disable-redirect], [Disable redirection of service output to /dev/null]),,[
 	enable_redirect=yes])
@@ -133,6 +141,12 @@ AS_IF([test "x$enable_auto_reload" = "xyes"], [
 
 AS_IF([test "x$enable_kernel_cmdline" = "xyes"], [
         AC_DEFINE(KERNEL_CMDLINE, 1, [Dumpster diving after init args from /proc/cmdline])])
+
+AS_IF([test "x$enable_fastboot" = "xyes"], [
+	AC_DEFINE(FAST_BOOT, 1, [Skip fsck check on filesystems listed in /etc/fstab])])
+
+AS_IF([test "x$enable_fsckfix" = "xyes"], [
+	AC_DEFINE(FSCK_FIX, 1, [Run fsck fix mode (options: -yf) on filesystems listed in /etc/fstab])])
 
 AS_IF([test "x$enable_redirect" = "xyes"], [
 	AC_DEFINE(REDIRECT_OUTPUT, 1, [Enable redirection of service output to /dev/null])])

--- a/src/finit.c
+++ b/src/finit.c
@@ -117,6 +117,7 @@ static int fsck(int pass)
 	while ((fs = getfsent())) {
 		char cmd[80];
 		struct stat st;
+		int fsck_rc = 0;
 
 		if (fs->fs_passno != pass)
 			continue;
@@ -134,8 +135,33 @@ static int fsck(int pass)
 			continue;
 		}
 
+#ifdef FSCK_FIX
+		snprintf(cmd, sizeof(cmd), "fsck -yf %s", fs->fs_spec);
+#else
 		snprintf(cmd, sizeof(cmd), "fsck -a %s", fs->fs_spec);
-		rc += run_interactive(cmd, "Checking filesystem %.13s", fs->fs_spec);
+#endif
+		fsck_rc = run_interactive(cmd, "Checking filesystem %.13s", fs->fs_spec);
+		/*
+		 * "failure" is defined as exiting with a return code of
+		 * 2 or larger.  A return code of 1 indicates that filesystem
+		 * errors were corrected but that the boot may proceed.
+		 */
+		if (fsck_rc > 1) {
+			char *sulogin[] = {
+				_PATH_SULOGIN,
+				"sulogin",
+			};
+
+			size_t i;
+			for (i = 0; i < NELEMS(sulogin); i++) {
+				if (systemf(sulogin[i]))
+					continue;
+				break;
+			}
+			do_shutdown(SHUT_REBOOT);
+
+		}
+		rc += fsck_rc;
 	}
 
 	endfsent();
@@ -145,14 +171,14 @@ static int fsck(int pass)
 
 static int fsck_all(void)
 {
-	int pass, rc = 0;
-
-	for (pass = 1; pass < 10; pass++) {
+	int rc = 0;
+#ifndef FAST_BOOT
+	for (int pass = 1; pass < 10; pass++) {
 		rc = fsck(pass);
 		if (rc)
 			break;
 	}
-
+#endif
 	return rc;
 }
 


### PR DESCRIPTION
fastboot: once enabled, fsck would be skipped on filesystems listed in
          /etc/fstab.
fsckfix: once enabled, 'fsck -ys' would be run instead of 'fsck -a',
         and check the return value larger than 1 as a failure and goes
         to login console.

They are both disabled by default, no functional changes unless an end
user choose to enable them.

The idea derives from Sysvinit's "FASTBOOT" and "FSCKFIX".

Signed-off-by: Ming Liu <liu.ming50@gmail.com>