### PR TITLE
Export libfinit library/headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_CONFIG_FILES([Makefile
 	man/Makefile
 	plugins/Makefile
 	src/Makefile
+	src/libfinit.pc
 	test/test.env
 	test/Makefile])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,7 +61,19 @@ if LOGROTATE
 finit_SOURCES     += logrotate.c
 endif
 
-pkginclude_HEADERS = cgroup.h cond.h finit.h helpers.h log.h plugin.h svc.h
+lib_LTLIBRARIES     = libfinit.la
+libfinit_la_SOURCES = $(finit_SOURCES)
+libfinit_la_CFLAGS  = $(finit_CFLAGS)
+libfinit_la_LIBADD  = $(finit_LDADD)
+
+pkginclude_HEADERS = cgroup.h cgutil.h client.h cond.h conf.h	\
+		     finit.h helpers.h initctl.h iwatch.h log.h	\
+		     pid.h plugin.h private.h schedule.h serv.h	\
+		     service.h sig.h sm.h svc.h tty.h util.h	\
+		     utmp-api.h watchdog.h
+pkgconfig_DATA     = libfinit.pc
+pkgconfigdir       = $(libdir)/pkgconfig
+pkgincludedir      = $(includedir)/finit
 
 finit_CFLAGS       = -W -Wall -Wextra -Wno-unused-parameter -std=gnu99
 finit_CFLAGS      += $(lite_CFLAGS) $(uev_CFLAGS)

--- a/src/libfinit.pc.in
+++ b/src/libfinit.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE@
+Description: Fast init for Linux systems
+Version: @VERSION@
+Requires:
+Libs: -L${libdir} -lfinit
+Cflags: -I${includedir}


### PR DESCRIPTION
So finit could be linked by other programs, for instance, if they want
to implement their own specific plugins.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>