### PR TITLE
service.c: set condition 'done' for oneshot tasks

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1677,6 +1677,21 @@ static void svc_set_state(svc_t *svc, svc_state_t new)
 		service_timeout_cancel(svc);
 		service_timeout_after(svc, svc->killdelay, service_kill);
 	}
+
+	if (svc_is_runtask(svc)) {
+		char cond[MAX_COND_LEN];
+
+		snprintf(cond, sizeof(cond), "%s/%s/done", svc->type, svc->name);
+
+		/* create done condition when entering SVC_DONE_STATE. */
+		if (*state == SVC_DONE_STATE)
+			cond_set_oneshot(cond);
+
+		/* clear done condition when entering SVC_HALTED_STATE. */
+		if (*state == SVC_HALTED_STATE)
+			cond_clear(cond);
+
+	}
 }
 
 /*


### PR DESCRIPTION
We like to know when a oneshot task is done, so as to start the
services that depending on it, set a oneshot condition 'done' for
that case.

Signed-off-by: Robert Andersson <robert.m.andersson@atlascopco.com>
Signed-off-by: Ming Liu <liu.ming50@gmail.com>