### PR TITLE
service.c: add more parameters when starting services

### DIFF
--- a/src/svc.h
+++ b/src/svc.h
@@ -70,6 +70,11 @@ typedef enum {
 	SVC_BLOCK_RESTARTING,
 } svc_block_t;
 
+typedef enum {
+	SVC_ONCRASH_IGNORE = 0,
+	SVC_ONCRASH_REBOOT = 1,
+} svc_oncrash_action_t;
+
 #define MAX_ID_LEN       16
 #define MAX_ARG_LEN      64
 #define MAX_IDENT_LEN    (MAX_ARG_LEN + MAX_ID_LEN + 1)
@@ -127,6 +132,9 @@ typedef struct svc {
 
 	/* Counters */
 	char           once;	       /* run/task, (at least) once per runlevel */
+	unsigned char  restart_max;    /* Maximum number of restarts allowed */
+	unsigned       restart_tmo;    /* Time required for the service to start. */
+	unsigned       oncrash_action; /* Action to perform in crashed state. */
 	char           respawn;	       /* ttys, or services with `respawn`, never increment restart_cnt */
 	const char     restart_cnt;    /* Incremented for each restart by service monitor. */
 


### PR DESCRIPTION
It would be good if we can control the services more specifically with
the following parameters like:

restart:N   - how many times shall the service to be restarted on
              failures (<10), the default max is 10.
restart_tmo - the timeout of the restarting.
norestart   - dont restart on failures.
oncrash     - once all retrying also fail, how to deal with it,
              rebooting or ignoring the failures.

Signed-off-by: Robert Andersson <robert.m.andersson@atlascopco.com>
Signed-off-by: Ming Liu <liu.ming50@gmail.com>