### PR TITLE
Fix filesystems not unmounted at shutdown

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -297,6 +297,20 @@ void do_sleep(unsigned int sec)
 		;
 }
 
+void do_usleep(unsigned int usec)
+{
+	struct timespec deadline;
+
+	clock_gettime(CLOCK_MONOTONIC, &deadline);
+
+	deadline.tv_nsec += usec * 1000;
+	deadline.tv_sec += deadline.tv_nsec / 1000000000;
+	deadline.tv_nsec = deadline.tv_nsec % 1000000000;
+
+	while (clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &deadline, NULL) != 0 && errno == EINTR)
+		;
+}
+
 /* Seconds since boot, from sysinfo() */
 long jiffies(void)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -64,6 +64,7 @@ char *sig2str      (int sig);
 char *code2str     (int code);
 
 void  do_sleep     (unsigned int sec);
+void  do_usleep    (unsigned int usec);
 long  jiffies      (void);
 char *uptime       (long secs, char *buf, size_t len);
 char *memsz        (uint64_t sz, char *buf, size_t len);


### PR DESCRIPTION
Instead of unconditionally waiting 2 seconds for processes to die,
check continuously for remaining processes, and break the loop when
none remain.

Turn PID 1 to a RT process with highest priority 99 during shutdown,
this ensures it would not be preempted by other RT processes.

Signed-off-by: Robert Andersson <robert.m.andersson@atlascopco.com>
Signed-off-by: Mathias Thore <mathias.thore@atlascopco.com>
Signed-off-by: Ming Liu <liu.ming50@gmail.com>