### PR TITLE
service.c: fix a regression

### DIFF
--- a/src/initctl.c
+++ b/src/initctl.c
@@ -292,7 +292,7 @@ static int dump_one_cond(const char *fpath, const struct stat *sb, int tflag, st
 	if (strncmp("pid/", cond, 4) == 0) {
 		svc_t *svc;
 
-		svc= client_svc_find_by_cond(cond);
+		svc = client_svc_find_by_cond(cond);
 		if (!svc) {
 			nm  = "unknown";
 			pid = 0;

--- a/src/service.c
+++ b/src/service.c
@@ -1709,7 +1709,7 @@ static void svc_set_state(svc_t *svc, svc_state_t new)
 	if (svc_is_runtask(svc)) {
 		char cond[MAX_COND_LEN];
 
-		snprintf(cond, sizeof(cond), "%s/%s/done", svc->type, svc->name);
+		snprintf(cond, sizeof(cond), "%s/%s/done", svc_typestr(svc), svc->name);
 
 		/* create done condition when entering SVC_DONE_STATE. */
 		if (*state == SVC_DONE_STATE)


### PR DESCRIPTION
A regression was introduced by commit f0f358a1:
[ service.c: set/clear condition 'done' for run tasks ]

svc->type is a integer but mistakenly being used as string, which will
cause crash.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>