### PR TITLE
Remove test code that may break tests

### DIFF
--- a/test/tenv/lib.sh
+++ b/test/tenv/lib.sh
@@ -101,7 +101,7 @@ teardown() {
     test_status="$?"
 
     if type test_teardown > /dev/null 2>&1 ; then
-	test_teardown
+        test_teardown
     fi
 
     log "$color_reset" '--' ''
@@ -116,9 +116,6 @@ teardown() {
 
     wait
 
-    if [ -d "$TENV_ROOT/var/lock" ]; then
-        chmod +r "$TENV_ROOT/var/lock"
-    fi
     rm -f "$TENV_ROOT"/running_test.pid
 }
 


### PR DESCRIPTION
In the test framework for finit, a set of shell scripts are used to
setup a test harness, run tests, and finalize tests. In the setup, a
file system is created for the virtualized/containerized environment in
which all tests are run, located at `$FINIT_SRC/test/tenv-root`. In the
tear down phase of each test, the file `/var/lock` is made readable
using `chmod +r`. It is not clear _why_ the teardown code does this, as
there are no references in the test framework to this path anywhere
else. It is conceivable that the teardown phase attempted to "reset the
state" for next test.
    
The code that that this commit removes does not always work. When
`/var/lock` is a symlink, and resolves to an absolute path, the test
framework does not function properly. The teardown code is run in the
context of the host computer, and touching files outside of the
virtualized environment is not ok.
    
The removal of the offending code does not seem to affect tests: all
tests pass without it, so its existence is questionable.

Signed-off-by: Jörgen Sigvardsson <jorgen.sigvardsson@gmail.com>