### PR TITLE
initctl.c: fix a return value of run tasks

### DIFF
--- a/src/initctl.c
+++ b/src/initctl.c
@@ -791,8 +791,15 @@ static int show_status(char *arg)
 		if (!svc)
 			return 255;
 
-		if (quiet)
-			return svc->state != SVC_RUNNING_STATE;
+		if (quiet) {
+			if (svc_is_runtask(svc))
+				if (svc->started)
+					return 0;
+				else
+					return 1;
+			else
+				return svc->state != SVC_RUNNING_STATE;
+		}
 
 		pidfn = svc->pidfile;
 		if (pidfn[0] == '!')

--- a/src/svc.h
+++ b/src/svc.h
@@ -332,7 +332,10 @@ static inline char *svc_status(svc_t *svc)
 		return "unknown";
 
 	case SVC_DONE_STATE:
-		return "done";
+		if (svc->started)
+			return "done";
+		else
+			return "failed";
 
 	case SVC_STOPPING_STATE:
 		switch (svc->type) {


### PR DESCRIPTION
When a run task is started with svc->started = 1, it should be
considered started successfully so it should return 0.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>