### PR TITLE
Support for coldplugging more devices

### DIFF
--- a/plugins/hotplug.c
+++ b/plugins/hotplug.c
@@ -95,7 +95,7 @@ static plugin_t plugin = {
 	.hook[HOOK_BASEFS_UP] = {
 		.cb  = setup
 	},
-	.depends = { "bootmisc" },
+	.depends = { "bootmisc", "modprobe" },
 };
 
 PLUGIN_INIT(plugin_init)


### PR DESCRIPTION
As it turns out, not all buses in Linux will add `modalias` attributes to their devices in sysfs. One notable exception are MDIO buses. The plugin's scan routine would thus not pick them up.

Fortunately, the information is always available in the device's `uevent` attribute.

Therefore, default to looking for modaliases in the device's `uevent` attribute instead, falling back to `modalias` only if `uevent` is not availble (this should never happen).
