### PR TITLE
Mark service dirty if the command line args have changed

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1666,7 +1666,7 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
 		parse_cgroup(svc, cgroup);
 
 	/* New, recently modified or unchanged ... used on reload. */
-	if ((file && conf_changed(file)) || conf_changed(svc_getenv(svc)))
+	if ((file && conf_changed(file)) || conf_changed(svc_getenv(svc)) || svc->args_dirty)
 		svc_mark_dirty(svc);
 	else
 		svc_mark_clean(svc);


### PR DESCRIPTION
This fixes `initctl reload` correctly restarting all daemons that have new command line arguments.
Previously command line arguments changes were only acted upon if the service was explicitly reloaded using `initctl reload myservice` since it blindly sets the `svc->dirty` flag.

When checking if a service should be restarted, `svc_is_changed()` checks for the `svc->dirty` flag, and then only after that will `svc_sighup()` look for the `svc->args_dirty` flag. Hence a difference in command line arguments would not result in a service being restarted. 
https://github.com/troglobit/finit/blob/9887003b25355c94c46e05985b9738297df6f1a8/src/service.c#L2289-L2293

You could also add the `|| svc->args_dirty` check into the `svc_is_changed()`, but I think it makes sense this way.