### PR TITLE
Add short sleep before rebooting

### DIFF
--- a/src/sig.c
+++ b/src/sig.c
@@ -375,6 +375,19 @@ void do_shutdown(shutop_t op)
 	run("mount -n -o remount,ro dummydev /", NULL);
 	run("mount -n -o remount,ro /", "mount");
 
+	/* Note that filesystems like ubifs might still have kernel threads
+	 * running after a successful dismount (e.g. wear-leveling). 
+	 * Give them time to finish before rebooting.
+	 * 
+	 * From the sync(8) manpage:
+	 * On Linux, sync is only guaranteed to schedule the dirty blocks for writing; 
+	 * it can actually take a short time before all the blocks are finally written. 
+	 * The reboot(8) and halt(8) commands take this into account by sleeping for a
+	 * few seconds after calling sync(2).
+	 */
+	sync();
+	do_sleep(1);
+
 	/* Call mdadm to mark any RAID array(s) as clean before halting. */
 	mdadm_wait();
 


### PR DESCRIPTION
This gives time for various kernel threads to finish any pending work. In particular this fixes a kernel panic in the ubifs wear-leveling that happens fairly often for me. It looks like after an umount ubifs is still performing some cleanup, or hasn't yet stopped all of its workers. 

You could probably just add a hook script with this one second delay in it, but looking at the [sync(8)](https://linux.die.net/man/8/sync) manpage I think it is appropriate for this sleep to be finits responsibility:
> Notes
On Linux, sync is only guaranteed to schedule the dirty blocks for writing; it can actually take a short time before all the blocks are finally written. The [reboot](https://linux.die.net/man/8/reboot)(8) and [halt](https://linux.die.net/man/8/halt)(8) commands take this into account by sleeping for a few seconds after calling [sync](https://linux.die.net/man/2/sync)(2).