### PR TITLE
Don't override BLOCK_USER on service reload

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1531,7 +1531,7 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
 		strlcpy(svc->cmd, cmd, sizeof(svc->cmd));
 
 		/* e.g., if missing cmd or env before */
-		if (!manual)
+		if (!manual && svc->block != SVC_BLOCK_USER)
 			svc_unblock(svc);
 	}
 


### PR DESCRIPTION
This might be more a personal choice, but at least how we are using finit if we stop a service manually (only done during debugging) we want it to stay stopped regardless of other things happening in the system.

I think this makes sense and follows systemd where reloading a config doesn't suddenly start the service (or other unrelated services).

Sorry for all the pull request spam, I just wanted to keep all the changes I've done isolated from each other. Feel free to reject any of these. 