### PR TITLE
Fix AUTO_RELOAD #define typo

### DIFF
--- a/src/cgroup.c
+++ b/src/cgroup.c
@@ -287,7 +287,7 @@ static void cgroup_events_cb(uev_t *w, void *arg, int events)
 		cgroup_handle_event(iwp->path, ev->mask);
 	}
 
-#ifdef ENABLE_AUTO_RELOAD
+#ifdef AUTO_RELOAD
 	if (conf_any_change())
 		service_reload_dynamic();
 #endif

--- a/src/conf.c
+++ b/src/conf.c
@@ -1133,7 +1133,7 @@ static void conf_cb(uev_t *w, void *arg, int events)
 		}
 	}
 
-#ifdef ENABLE_AUTO_RELOAD
+#ifdef AUTO_RELOAD
 	if (conf_any_change())
 		service_reload_dynamic();
 #endif


### PR DESCRIPTION
It looks like the makefiles are creating a `AUTO_RELOAD` define, but the code is looking for `ENABLE_AUTO_RELOAD`. Making this change fixes the auto-reload feature for me. 

I also noticed that `conf.c do_change()` seems to ignore deleted files. 
Commenting out this checks causes a deleted or moved .conf to correctly remove a service. Not sure why this check is here so I'm afraid I might be missing some edge-cases.

```diff
 static int do_change(char *dir, char *name, uint32_t mask) 
 { 
 	char fn[strlen(dir) + strlen(name) + 2]; 
 	struct conf_change *node; 
  
 	paste(fn, sizeof(fn), dir, name); 
 	dbg("path: %s mask: %08x", fn, mask); 
  
 	node = conf_find(fn); 
- 	if (mask & (IN_DELETE | IN_MOVED_FROM)) { 
- 		drop_change(node); 
- 		return 0; 
- 	}
	if (node) {
		dbg("Event already registered for %s ...", name);
		return 0;
	}
```