### PR TITLE
Fix shutdown hooks not running

### DIFF
--- a/src/sig.c
+++ b/src/sig.c
@@ -330,7 +330,7 @@ void do_shutdown(shutop_t op)
 		;
 
 	/* All services and (non-critical) processes have stopped. */
-	plugin_run_hooks(HOOK_SVC_DN);
+	plugin_script_run(HOOK_SVC_DN);
 
 	if (in_cont) {
 		if (osheading)
@@ -380,7 +380,7 @@ void do_shutdown(shutop_t op)
 
 	/* Last chance to run scripts (all .so plugins have exited already) */
 	print(0, "Calling hook/svc/down scripts ...");
-	plugin_run_hooks(HOOK_SYS_DN);
+	plugin_script_run(HOOK_SYS_DN);
 
 	/* Reboot via watchdog or kernel, or shutdown? */
 	if (op == SHUT_REBOOT) {


### PR DESCRIPTION
The shutdown hooks do not have any registered callbacks. So calling `plugin_run_hooks()` ends up doing nothing.  

I think it makes sense to handle these special case hook scripts like this, but not sure if skipping some of the extra checks in `plugin_run_hooks()` makes a difference. I am guessing we don't care about the `cond_set()` and `service_step()` calls when everything has already exited. 