### PR TITLE
initctl: Follow priciple of least surprise for "cond get"

### DIFF
--- a/man/initctl.8
+++ b/man/initctl.8
@@ -145,7 +145,7 @@ or
 then any condition can be read.
 .Pp
 The command is geared for scripting, check the exit code to get the
-status of the condition: 0 - off, 1 - on, 255 - flux.  For a more
+status of the condition: 0 - on, 1 - off, 255 - flux.  For a more
 verbose output, use the
 .Fl v
 option.


### PR DESCRIPTION
The accepted standard in Unix is to report successful executions with exitcode 0. Therefore, map a "initctl cond get" of a condition to the following exitcodes:

- On: 0
- Off: 1
- Flux: 255

Fixes: c3c662fe6446 ("initctl: ensure 'cond get' support flux state")
Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>