### PR TITLE
Set hostname as soon as possible

### DIFF
--- a/src/finit.c
+++ b/src/finit.c
@@ -648,6 +648,11 @@ int main(int argc, char *argv[])
 		rescue = sulogin(0);
 #endif
 
+	/* Set hostname as soon as possible, so it could be accessed
+	 * in plugins.
+	 */
+	set_hostname(&hostname);
+
 	/*
 	 * Load plugins early, the first hook is in banner(), so we
 	 * need plugins loaded before calling it.


### PR DESCRIPTION
We find it's useful to get know hostname before plugins get initialized, since some plugins might want to do some machine specific settings.

This change mainly aims to satisfy that requirement, to set hostname as soon as possible in main function.