### PR TITLE
wishlist: option for progress output on all runlevels

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,10 @@ AC_ARG_ENABLE(fastboot,
         AS_HELP_STRING([--enable-fastboot], [Skip fsck check on filesystems listed in /etc/fstab]),,[
 	enable_fastboot=no])
 
+AC_ARG_ENABLE(allprogress,
+        AS_HELP_STRING([--enable-allprogress], [Progress output on all runlevels, not just S]),,[
+	enable_allprogress=no])
+
 AC_ARG_ENABLE(fsckfix,
         AS_HELP_STRING([--enable-fsckfix], [Run fsck fix mode (options: -yf) on filesystems listed in /etc/fstab]),,[
 	enable_fsckfix=no])
@@ -179,6 +183,10 @@ AS_IF([test "x$enable_kernel_cmdline" = "xyes"], [
 
 AS_IF([test "x$enable_fastboot" = "xyes"], [
 	AC_DEFINE(FAST_BOOT, 1, [Skip fsck check on filesystems listed in /etc/fstab])])
+
+AS_IF([test "x$enable_allprogress" = "xyes"], [
+	AC_DEFINE(ALL_PROGRESS, 1, [Progress output on all runlevels, not just S])])
+
 
 AS_IF([test "x$enable_fsckfix" = "xyes"], [
 	AC_DEFINE(FSCK_FIX, 1, [Run fsck fix mode (options: -yf) on filesystems listed in /etc/fstab])])

--- a/src/sm.c
+++ b/src/sm.c
@@ -218,7 +218,7 @@ restart:
 		plugin_run_hooks(HOOK_SYSTEM_UP);
 		service_step_all(SVC_TYPE_ANY);
 
-#ifndef ALLPROGRESS
+#ifndef ALL_PROGRESS
 		/* Disable progress output at normal runtime */
 		enable_progress(0);
 #endif

--- a/src/sm.c
+++ b/src/sm.c
@@ -218,8 +218,10 @@ restart:
 		plugin_run_hooks(HOOK_SYSTEM_UP);
 		service_step_all(SVC_TYPE_ANY);
 
+#ifndef ALLPROGRESS
 		/* Disable progress output at normal runtime */
 		enable_progress(0);
+#endif
 
 		/* System bootrapped, launch TTYs et al */
 		bootstrap = 0;


### PR DESCRIPTION
i found debugging of finit's behaviour at and after the transition to runlevel 2 a bit troublesome, because all progress output stops when finit leaves runlevel S.

this PR adds the configure option ```--enable-allprogress```, which when enabled makes finit print progress outputs to the console on all runlevels instead of just S.

if that change is deemed too ugly/intrusive, then i'd suggest reviewing and fixing up the ```SM_BOOTSTRAP_WAIT_STATE``` logic in sm_step(), because that currently kills progress outputs before any level 2 services are started and that behaviour doesn't correspond to what man/finit.8 says about progress output, which is
```
When all services and run/tasks have been started, the console progress
is disabled and all configured getty services are started.
```
