### PR TITLE
Fix log child exiting with debug disabled

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -330,14 +330,15 @@ static int lredirect(svc_t *svc)
 
 				snprintf(rot, sizeof(rot), "%d:%d", logfile_size_max, logfile_count_max);
 				snprintf(pid, sizeof(pid), "%d", svc_pid);
-				execlp("logger", "logger", "-f", svc->log.file, "-b", "-t", tag, "-p", prio, debug ? "-s" : "", "-I", pid, "-r", rot, NULL);
+				execlp("logger", "logger", "-f", svc->log.file, "-b", "-t", tag, "-p", prio, "-I", pid, "-r", rot, debug ? "-s" : NULL, NULL);
 			} else {
 				char sz[20], num[3];
 
 				snprintf(sz, sizeof(sz), "%d", logfile_size_max);
 				snprintf(num, sizeof(num), "%d", logfile_count_max);
 
-				execlp(_PATH_LOGIT, "logit", "-f", svc->log.file, "-n", sz, "-r", num, debug ? "-s" : "", NULL);
+				execlp(_PATH_LOGIT, "logit", "-f", svc->log.file, "-n", sz, "-r", num, debug ? "-s" : NULL, NULL);
+
 			}
 			_exit(1);
 		}
@@ -351,9 +352,9 @@ static int lredirect(svc_t *svc)
 			char pid[16];
 
 			snprintf(pid, sizeof(pid), "%d", svc_pid);
-			execlp("logger", "logger", "-t", tag, "-p", prio, debug ? "-s" : "", "-I", pid, NULL);
+			execlp("logger", "logger", "-t", tag, "-p", prio, "-I", pid, debug ? "-s" : NULL, NULL);
 		} else {
-			execlp(_PATH_LOGIT, "logit", "-t", tag, "-p", prio, debug ? "-s" : "", NULL);
+			execlp(_PATH_LOGIT, "logit", "-t", tag, "-p", prio, debug ? "-s" : NULL, NULL);
 		}
 		_exit(1);
 	}


### PR DESCRIPTION
When debug is disabled an empty string `""` is sent as an arg to the logger process specified with `log`, both `logit` and `logger` interpret this as a log message and exit after emitting a single message containing the following parameters.