### PR TITLE
Fix compilation on musl by implementing a custom basename

### DIFF
--- a/plugins/modprobe.c
+++ b/plugins/modprobe.c
@@ -132,11 +132,10 @@ static FILE *maybe_fopen_alias(const char *file, const char *path)
 {
 	const char *basename;
 
-	basename = rindex(path, '/');
-	if (!basename)
+	basename = basenm(path);
+	if (!strcmp(basename, path))
 		return NULL;
 
-	basename++;
 	if (strcmp(file, basename))
 		return NULL;
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <string.h>
+#include <libgen.h>
 #include <sys/inotify.h>
 #include <sys/resource.h>
 #ifdef _LIBITE_LITE

--- a/src/conf.c
+++ b/src/conf.c
@@ -26,7 +26,6 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <string.h>
-#include <libgen.h>
 #include <sys/inotify.h>
 #include <sys/resource.h>
 #ifdef _LIBITE_LITE
@@ -1312,7 +1311,7 @@ int conf_reload(void)
 			if (strncmp(path, FINIT_SYSPATH_, strlen(FINIT_SYSPATH_)) &&
 			    strncmp(path, FINIT_RUNPATH_, strlen(FINIT_RUNPATH_)))
 				continue;
-			if (strcmp(basename(path), basename(gl.gl_pathv[j])))
+			if (strcmp(basenm(path), basenm(gl.gl_pathv[j])))
 				continue;
 			path = NULL; /* replacement later in list, skip this */
 			break;

--- a/src/mdadm.c
+++ b/src/mdadm.c
@@ -26,9 +26,9 @@
 #include <glob.h>
 #include <stdio.h>
 #include <string.h>
-#include <libgen.h>
 
 #include "helpers.h"
+#include "util.h"
 
 
 static glob_t *get_arrays(void)
@@ -59,7 +59,7 @@ void mdadm_wait(void)
 		for (i = 0; i < gl->gl_pathc; i++) {
 			char *array;
 
-			array = basename(gl->gl_pathv[i]);
+			array = basenm(gl->gl_pathv[i]);
 			snprintf(cmd, sizeof(cmd), "mdadm --wait-clean /dev/%s >/dev/null", array);
 			run_interactive(cmd, "Marking MD array %s as clean", array);
 		}

--- a/src/mdadm.c
+++ b/src/mdadm.c
@@ -26,6 +26,7 @@
 #include <glob.h>
 #include <stdio.h>
 #include <string.h>
+#include <libgen.h>
 
 #include "helpers.h"
 

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -28,6 +28,7 @@
 #include <dirent.h>		/* readdir() et al */
 #include <poll.h>
 #include <string.h>
+#include <libgen.h>
 #ifdef _LIBITE_LITE
 # include <libite/lite.h>
 # include <libite/queue.h>	/* BSD sys/queue.h API */
@@ -86,9 +87,11 @@ int plugin_register(plugin_t *plugin)
 	if (!plugin->name) {
 #ifndef ENABLE_STATIC
 		Dl_info info;
+		char *dli_fname = strdup(info.dli_fname);
 
-		if (dladdr(plugin, &info) && info.dli_fname)
-			plugin->name = basename(info.dli_fname);
+		if (dladdr(plugin, &info) && dli_fname)
+			plugin->name = basename(dli_fname);
+		free(dli_fname);
 #endif
 		if (!plugin->name)
 			plugin->name = "unknown";

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -28,7 +28,6 @@
 #include <dirent.h>		/* readdir() et al */
 #include <poll.h>
 #include <string.h>
-#include <libgen.h>
 #ifdef _LIBITE_LITE
 # include <libite/lite.h>
 # include <libite/queue.h>	/* BSD sys/queue.h API */
@@ -44,6 +43,7 @@
 #include "private.h"
 #include "service.h"
 #include "sig.h"
+#include "util.h"
 
 #define is_io_plugin(p) ((p)->io.cb && (p)->io.fd > 0)
 #define SEARCH_PLUGIN(str)						\
@@ -87,11 +87,9 @@ int plugin_register(plugin_t *plugin)
 	if (!plugin->name) {
 #ifndef ENABLE_STATIC
 		Dl_info info;
-		char *dli_fname = strdup(info.dli_fname);
 
-		if (dladdr(plugin, &info) && dli_fname)
-			plugin->name = basename(dli_fname);
-		free(dli_fname);
+		if (dladdr(plugin, &info) && info.dli_fname)
+			plugin->name = basenm(info.dli_fname);
 #endif
 		if (!plugin->name)
 			plugin->name = "unknown";
@@ -256,7 +254,7 @@ void plugin_run_hook(hook_point_t no, void *arg)
 
 	PLUGIN_ITERATOR(p, tmp) {
 		if (p->hook[no].cb) {
-			dbg("Calling %s hook n:o %d (arg: %p) ...", basename(p->name), no, arg ?: "NIL");
+			dbg("Calling %s hook n:o %d (arg: %p) ...", basenm(p->name), no, arg ?: "NIL");
 			p->hook[no].cb(arg ? arg : p->hook[no].arg);
 		}
 	}
@@ -304,9 +302,9 @@ int plugin_io_init(plugin_t *p)
 	if (!is_io_plugin(p))
 		return 0;
 
-	dbg("Initializing plugin %s for I/O", basename(p->name));
+	dbg("Initializing plugin %s for I/O", basenm(p->name));
 	if (uev_io_init(ctx, &p->watcher, generic_io_cb, p, p->io.fd, p->io.flags)) {
-		warn("Failed setting up I/O plugin %s", basename(p->name));
+		warn("Failed setting up I/O plugin %s", basenm(p->name));
 		return 1;
 	}
 

--- a/src/tmpfiles.c
+++ b/src/tmpfiles.c
@@ -492,7 +492,7 @@ void tmpfilesd(void)
 
 		/* check for overrides */
 		for (j = i + 1; j < gl.gl_pathc; j++) {
-			if (strcmp(basename(fn), basename(gl.gl_pathv[j])))
+			if (strcmp(basenm(fn), basenm(gl.gl_pathv[j])))
 				continue;
 			fn = NULL;
 			break;

--- a/src/util.c
+++ b/src/util.c
@@ -151,14 +151,9 @@ char *progname(char *arg0)
        return prognm;
 }
 
-/**
- * basenm - Our custom basename implementation
- * @path: The path to parse
- *
- * Returns either the parsed basename, or
- * a copy of the given path
-*/
-char *basenm(const char *path) {
+/* basename(3) replacement that does not modify its argument */
+char *basenm(const char *path)
+{
 	char *basename;
 
 	basename = rindex(path, '/');

--- a/src/util.c
+++ b/src/util.c
@@ -151,6 +151,24 @@ char *progname(char *arg0)
        return prognm;
 }
 
+/**
+ * basenm - Our custom basename implementation
+ * @path: The path to parse
+ *
+ * Returns either the parsed basename, or
+ * a copy of the given path
+*/
+char *basenm(const char *path) {
+	char *basename;
+
+	basename = rindex(path, '/');
+	if (!basename)
+		return (char *) path;
+
+	basename++;
+	return basename;
+}
+
 char *str(char *fmt, ...)
 {
 	static char buf[32];

--- a/src/util.h
+++ b/src/util.h
@@ -55,6 +55,7 @@ extern char *prognm;
 #endif
 
 char *progname     (char *arg0);
+char *basenm       (const char *path);
 
 char *str          (char *fmt, ...)                        __attribute__ ((format (printf, 1, 2)));
 int   fnread       (char *buf, size_t len, char *fmt, ...) __attribute__ ((format (printf, 3, 4)));


### PR DESCRIPTION
This PR fixes #389.
Tested on a glibc and musl system.

### Changes
- Implemented a custom `basename()` version: `basenm()` using the simple implementation of it that was present in `maybe_fopen_alias()`
- Modified the simple implementation of it to return a copy of the argument that was given, instead of `NULL` if no `/` was present
- Changed all calls to `basename()` to our custom version
- Changed the comparison in `maybe_fopen_alias()` as we no longer return `NULL`