### PR TITLE
configure.ac: make cgroup2 configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -395,7 +395,7 @@ Optional features:
   Built-in sulogin......: $with_sulogin $sulogin
   Built-in watchdogd....: $with_watchdog $watchdog
   Built-in logrotate....: $enable_logrotate
-  Check cgroup2.........: $enable_cgroup2
+  Use cgroup v2.........: $enable_cgroup
   Parse kernel cmdline..: $enable_kernel_cmdline
   Keep kernel logging...: $enable_kernel_logging
   Skip fsck check.......: $enable_fastboot

--- a/configure.ac
+++ b/configure.ac
@@ -59,10 +59,6 @@ AC_ARG_ENABLE(kernel_cmdline,
         AS_HELP_STRING([--enable-kernel-cmdline], [Parse init args from /proc/cmdline (don't use!)]),,[
 	enable_kernel_cmdline=no])
 
-AC_ARG_ENABLE(cgroup2,
-        AS_HELP_STRING([--disable-cgroup2], [Disable checking cgroup v2 available from /sys/fs/cgroup]),,[
-        enable_cgroup2=yes])
-
 AC_ARG_ENABLE(fastboot,
         AS_HELP_STRING([--enable-fastboot], [Skip fsck check on filesystems listed in /etc/fstab]),,[
 	enable_fastboot=no])
@@ -70,6 +66,10 @@ AC_ARG_ENABLE(fastboot,
 AC_ARG_ENABLE(fsckfix,
         AS_HELP_STRING([--enable-fsckfix], [Run fsck fix mode (options: -yf) on filesystems listed in /etc/fstab]),,[
 	enable_fsckfix=no])
+
+AC_ARG_ENABLE(cgroup,
+        AS_HELP_STRING([--disable-cgroup], [Disable cgroup v2 support, default: autodetect from /sys/fs/cgroup]),,[
+        enable_cgroup=yes])
 
 AC_ARG_ENABLE(redirect,
         AS_HELP_STRING([--disable-redirect], [Disable redirection of service output to /dev/null]),,[
@@ -192,8 +192,8 @@ AS_IF([test "x$enable_kernel_cmdline" = "xyes"], [
 AS_IF([test "x$enable_kernel_logging" = "xyes"], [
         AC_DEFINE(KERNEL_LOGGING, 1, [Keep kernel warn/err logs to console])])
 
-AS_IF([test "x$enable_cgroup2" = "xyes"], [
-        AC_DEFINE(CGROUP2_ENABLED, 1, [Check cgroup v2 available from /sys/fs/cgroup])])
+AS_IF([test "x$enable_cgroup" = "xyes"], [
+        AC_DEFINE(CGROUP2_ENABLED, 1, [Autodetect cgroup v2 support from /sys/fs/cgroup])])
 
 AS_IF([test "x$enable_fastboot" = "xyes"], [
 	AC_DEFINE(FAST_BOOT, 1, [Skip fsck check on filesystems listed in /etc/fstab])])

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,10 @@ AC_ARG_ENABLE(kernel_cmdline,
         AS_HELP_STRING([--enable-kernel-cmdline], [Parse init args from /proc/cmdline (don't use!)]),,[
 	enable_kernel_cmdline=no])
 
+AC_ARG_ENABLE(cgroup2,
+        AS_HELP_STRING([--disable-cgroup2], [Disable checking cgroup v2 available from /sys/fs/cgroup]),,[
+        enable_cgroup2=yes])
+
 AC_ARG_ENABLE(fastboot,
         AS_HELP_STRING([--enable-fastboot], [Skip fsck check on filesystems listed in /etc/fstab]),,[
 	enable_fastboot=no])
@@ -187,6 +191,9 @@ AS_IF([test "x$enable_kernel_cmdline" = "xyes"], [
 
 AS_IF([test "x$enable_kernel_logging" = "xyes"], [
         AC_DEFINE(KERNEL_LOGGING, 1, [Keep kernel warn/err logs to console])])
+
+AS_IF([test "x$enable_cgroup2" = "xyes"], [
+        AC_DEFINE(CGROUP2_ENABLED, 1, [Check cgroup v2 available from /sys/fs/cgroup])])
 
 AS_IF([test "x$enable_fastboot" = "xyes"], [
 	AC_DEFINE(FAST_BOOT, 1, [Skip fsck check on filesystems listed in /etc/fstab])])
@@ -388,6 +395,7 @@ Optional features:
   Built-in sulogin......: $with_sulogin $sulogin
   Built-in watchdogd....: $with_watchdog $watchdog
   Built-in logrotate....: $enable_logrotate
+  Check cgroup2.........: $enable_cgroup2
   Parse kernel cmdline..: $enable_kernel_cmdline
   Keep kernel logging...: $enable_kernel_logging
   Skip fsck check.......: $enable_fastboot

--- a/src/cgroup.c
+++ b/src/cgroup.c
@@ -463,6 +463,11 @@ void cgroup_init(uev_ctx_t *ctx)
 	FILE *fp;
 	int fd;
 
+#ifndef CGROUP2_ENABLED
+	avail = 0;
+	return;
+#endif
+
 	if (mount("none", FINIT_CGPATH, "cgroup2", opts, NULL)) {
 		if (errno == ENOENT)
 			logit(LOG_INFO, "Kernel does not support cgroups v2, disabling.");


### PR DESCRIPTION
We would like cgroup2 to be configurable at build time, when it's disabled, finit will not check /sys/fs/cgroup for cgroup2 support.

The reason for why we need this is because we'd like to use our own rules for controlling cgroup2, and it's hard to adapt to finit's default settings.