### PR TITLE
Avoid remounting already mounted /run and /tmp directories

### DIFF
--- a/src/finit.c
+++ b/src/finit.c
@@ -409,7 +409,7 @@ static void fs_finalize(void)
 	 * To override any of this behavior, add entries to /etc/fstab
 	 * for /run (and optionally /run/lock).
 	 */
-	if (fisdir("/run") && !fismnt("/run")) {
+	if (fisdir("/run") && !fismnt("/run") && !fistmpfs("/run")) {
 		fs_mount("tmpfs", "/run", "tmpfs", MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_RELATIME, "mode=0755,size=10%");
 
 		/* This prevents user DoS of /run by filling /run/lock at the expense of another tmpfs, max 5MiB */
@@ -418,7 +418,7 @@ static void fs_finalize(void)
 	}
 
 	/* Modern systems use tmpfs for /tmp */
-	if (!fismnt("/tmp"))
+	if (!fismnt("/tmp") && !fistmpfs("/tmp"))
 		fs_mount("tmpfs", "/tmp", "tmpfs", MS_NOSUID | MS_NODEV, "mode=1777");
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -42,6 +42,8 @@
 # include <sys/ioctl.h>
 #endif
 #include <sys/sysinfo.h>	/* sysinfo() */
+#include <sys/vfs.h> /* statfs */
+#include <linux/magic.h>
 #ifdef _LIBITE_LITE
 # include <libite/lite.h>
 #else
@@ -570,6 +572,20 @@ int ismnt(char *file, char *dir, char *mode)
 int fismnt(char *dir)
 {
 	return ismnt("/proc/mounts", dir, NULL);
+}
+
+/* Return 1 if dir is a backed by tmpfs or overlayfs */
+int fistmpfs(char *dir)
+{
+	struct statfs info = {0};
+
+	if (statfs(dir, &info))
+		return 0;
+
+	if (info.f_type == TMPFS_MAGIC || info.f_type == OVERLAYFS_SUPER_MAGIC)
+		return 1;
+
+	return 0;
 }
 
 #ifdef HAVE_TERMIOS_H

--- a/src/util.h
+++ b/src/util.h
@@ -80,6 +80,7 @@ void  de_dotdot    (char *file);
 
 int   ismnt        (char *file, char *dir, char *mode);
 int   fismnt       (char *dir);
+int   fistmpfs     (char *dir);
 
 #ifdef HAVE_TERMIOS_H
 int     ttinit     (void);


### PR DESCRIPTION
This is a patch for finit 4.8 beta 1.

It adds the function fistmpfs to determine if a new tmpfs mount should be performed on /run and /tmp. The function supports cases where more complex mount hierarchies are in use, including overlayfs backed mounts.

In our system, /tmp is a symbolic link to a subdirectory in an overlayfs mount. This means that /tmp does not explicitly show up in /proc/mounts, so in fs_finalize, finit decides to mount a new tmpfs on top of it.

This turns out to be problematic for our smallest systems where the new tmpfs on /tmp is not large enough.

I do realize this may be a bit particular to our specific setup, but the patch works on our system. Any comments are welcome.