### PR TITLE
tmpfiles.c: prevent nftw follow symbolic links

### DIFF
--- a/src/tmpfiles.c
+++ b/src/tmpfiles.c
@@ -90,7 +90,7 @@ static int rmrf(const char *path)
 	if (!fisdir(path))
 		return 0;
 
-	nftw(path, do_delete, 20, FTW_DEPTH);
+	nftw(path, do_delete, 20, FTW_DEPTH | FTW_PHYS);
 	if (remove(path) && errno != ENOENT)
 		warn("Failed removing path %s", path);
 


### PR DESCRIPTION
When dealing with "L+" and "R", the function call 'nftw' should not follow symbolic links, otherwise, it would also delete the targets which is wrong.

For instance, if there is already a symbolic link:
```
/path/to/the/link -> /path/to/some/folder
```

if we set the following in a tmpfile conf:

```
L+ /path/to/the/link -    -    -     - /path/to/the/target
```

the result would be /path/to/some/folder also get deleted, which it should not.

it could be even worse, when the symbolic link already is pointing to: /path/to/the/target, the whole /path/to/the/target would be deleted on next system boot.