### PR TITLE
fstab with UUID/LABEL: nofail handling for fsck

### DIFF
--- a/src/finit.c
+++ b/src/finit.c
@@ -272,8 +272,13 @@ static int fsck(int pass)
 		 * errors were corrected but that the boot may proceed.
 		 */
 		if (fsck_rc > 1) {
-			logit(LOG_CONSOLE | LOG_ALERT, "Failed fsck %s, attempting sulogin ...", dev);
-			sulogin(1);
+			if (hasmntopt(mnt,"nofail")) {
+                        	logit(LOG_CONSOLE | LOG_WARNING, "Ignoring failed fsck %s because of nofail option", dev);
+                        	fsck_rc = 0;
+			} else {
+				logit(LOG_CONSOLE | LOG_ALERT, "Failed fsck %s, attempting sulogin ...", dev);
+				sulogin(1);
+			}
 		}
 		rc += fsck_rc;
 	}


### PR DESCRIPTION
fix for #421: add support for 'nofail' fstab option. if present, finit's fsck invocation ignores errors for this device.

this is useful if you have an fstab entry for a device with UUID= or LABEL= which isn't always present and which you'd like to not  bail on (so you set nofail). in this case finit leaves the presence-or-not decision to fsck, which exits nonzero.

for block devices that are directly listed in fstab this change isn't important, because for such finit looks for the blockdev's existence and skips the fsck if n/a.