### PR TITLE
add systemd-nspawn to the list of container types

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -585,7 +585,8 @@ int in_container(void)
 		"lxc",
 		"docker",
 		"kubepod",
-		"unshare"
+		"unshare",
+		"systemd-nspawn"
 	};
 	const char *files[] = {
 		"/run/.containerenv",


### PR DESCRIPTION
i wanted to play around with `finit` a little bit so i launched it as pid1 in a `systemd-nspawn` container - i noticed that the `container` condition wasn't met

before patch:
```
$ initctl cond dump | grep container
```

after patch:
```
$ initctl cond dump | grep container
1    init                on      <int/container>
```

may or may not be useful to others, thought i would submit in case - thank you