### PR TITLE
improve notify:s6 compatibility

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -2912,7 +2912,7 @@ void service_notify_cb(uev_t *w, void *arg, int events)
 	}
 
 	len = read(w->fd, buf, sizeof(buf) - 1);
-	if (len == -1) {
+	if (len <= 0) {
 		warn("Failed reading notification from %s", svc_ident(svc, NULL, 0));
 		return;
 	}
@@ -2920,7 +2920,7 @@ void service_notify_cb(uev_t *w, void *arg, int events)
 	buf[len] = 0;
 
 	/* systemd and s6, respectively.  The latter then closes the socket */
-	if (!strcmp(buf, "READY=1\n") || !strcmp(buf, "\n")) {
+	if (!strcmp(buf, "READY=1\n") || buf[len - 1] == '\n') {
 		/*
 		 * native (pidfile) services are marked as started by
 		 * the pidfile plugin.


### PR DESCRIPTION
citing https://skarnet.org/software/s6/notifywhenup.html

> - When your daemon is ready, write a newline to this file descriptor.
>   - If you like, you may write other data before the newline, just in case it is printed to the terminal. It is not necessary, and it is best to keep that data short. If the line is read by [s6-supervise](https://skarnet.org/software/s6/s6-supervise.html), it will be entirely ignored; only the newline is important.

while testing out [eudev support for s6 style readiness notifications](https://github.com/eudev-project/eudev/pull/290) i found out that `finit` is a bit too strict in its implementation

this patch relaxes `finit` check so it better implements the spec