### PR TITLE
service.c/parse_cmdline_args: handle loooooong arguments

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1374,7 +1374,7 @@ static char *parse_name(char *cmd, char *arg)
  */
 static void parse_cmdline_args(svc_t *svc, char *cmd, char **args)
 {
-	char prev[MAX_ARG_LEN];
+	char prev[MAX_CMD_LEN];
 	int diff = 0;
 	char sep = 0;
 	char *arg;


### PR DESCRIPTION
https://github.com/troglobit/finit/blob/2760616c73af1284bd71ae9aa8226c3da3ff8544/src/service.c#L1420

`prev` and `svc->args[...]` are compared but `prev` has less bytes available than `svc->args[...]` does, which can result in truncated data being compared to determine if a service is dirty

for example:

```
service [234] name:mariadb restart:10 @mariadb:mariadb <!service/syslogd/ready,task/mariadb-init/success> notify:systemd log /nix/store/z5lmh4g28xxbdjc6zsblajw91fnmjd8d-mariadb-server-10.11.13/bin/mysqld --defaults-file=/etc/my.cnf --user=mariadb --datadir=/var/lib/mariadb --basedir=/nix/store/z5lmh4g28xxbdjc6zsblajw91fnmjd8d-mariadb-server-10.11.13 -- mariadb database service
```

this results in `finit` marking some of my services as dirty every time i run `initctl reload`

by giving `prev` the same size as what it will be compared against we can ensure a valid comparison

fully tested on my machine and ready to go :+1: