### PR TITLE
sd-daemon.c: fix a compilation error

### DIFF
--- a/libsystemd/Makefile.am
+++ b/libsystemd/Makefile.am
@@ -2,6 +2,8 @@
 lib_LTLIBRARIES          = libsystemd.la
 libsystemd_la_SOURCES    = sd-daemon.c sd-daemon.h
 libsystemd_la_LDFLAGS    = -version-info 0:0:0
+libsystemd_la_CFLAGS     = $(lite_CFLAGS)
+libsystemd_la_LIBADD     = $(lite_LIBS)
 
 # pkg-config support
 pkgconfigdir = $(libdir)/pkgconfig

--- a/libsystemd/sd-daemon.c
+++ b/libsystemd/sd-daemon.c
@@ -23,6 +23,11 @@
 #include <sys/un.h>
 #include <time.h>
 #include <unistd.h>
+#ifdef _LIBITE_LITE
+# include <libite/lite.h>
+#else
+# include <lite/lite.h>
+#endif
 
 #include "sd-daemon.h"
 

--- a/test/src/Makefile.am
+++ b/test/src/Makefile.am
@@ -3,6 +3,7 @@ noinst_PROGRAMS = serv
 serv_SOURCES    = serv.c
 serv_CPPFLAGS   = -D_XOPEN_SOURCE=600 -D_BSD_SOURCE -D_GNU_SOURCE -D_DEFAULT_SOURCE -I$(top_builddir)
 if LIBSYSTEMD
-serv_CPPFLAGS  += -I$(top_srcdir)/libsystemd
+serv_CPPFLAGS  += -I$(top_srcdir)/libsystemd $(lite_CFLAGS)
 serv_SOURCES   += $(top_srcdir)/libsystemd/sd-daemon.c
+serv_LDADD      = $(lite_LIBS)
 endif


### PR DESCRIPTION
A following compilation error was observed:
| libsystemd/sd-daemon.c:64: undefined reference to `strlcpy'

fix it by include the required libite dependency.