### PR TITLE
Fix elogind path in elogind.conf

### DIFF
--- a/contrib/debian/finit.d/available/elogind.conf
+++ b/contrib/debian/finit.d/available/elogind.conf
@@ -1,4 +1,4 @@
 # On some systems, bootstrap can be really quick and cause elogind
 # to not start before a user has managed to log in.  To prevent
 # this, add <pid/elogind> as condition to your TTYs in getty.conf
-service [2345] <pid/syslogd> /lib/elogind/elogind -- Login manager
+service [2345] <pid/syslogd> /usr/libexec/elogind -- Login manager


### PR DESCRIPTION
On Debian and Debian-derived distro, the elogind is place at /usr/libexec/elogind