### PR TITLE
netlink: enumerate existing interfaces at startup

### DIFF
--- a/plugins/netlink.c
+++ b/plugins/netlink.c
@@ -406,9 +406,29 @@ static void nl_reconf(void *arg)
 	cond_reassert("net/");
 }
 
+/*
+ * Initial enumeration of existing interfaces and routes.  Called from
+ * HOOK_SVC_PLUGIN which runs after the condition system is initialized.
+ * Interfaces that exist before finit starts (e.g., virtio-net in QEMU)
+ * won't generate RTM_NEWLINK events, so we must query for them.
+ */
+static void nl_enumerate(void *arg)
+{
+	int sd;
+
+	sd = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
+	if (sd < 0)
+		return;
+
+	nl_resync_ifaces(sd, 0);
+	nl_resync_routes(sd, 1);
+	close(sd);
+}
+
 static plugin_t plugin = {
 	.name = __FILE__,
-	.hook[HOOK_SVC_RECONF] = { .cb = nl_reconf },
+	.hook[HOOK_SVC_RECONF]  = { .cb = nl_reconf },
+	.hook[HOOK_SVC_PLUGIN]  = { .cb = nl_enumerate },
 	.io = {
 		.cb    = nl_callback,
 		.flags = PLUGIN_IO_READ,


### PR DESCRIPTION
The netlink plugin only receives RTM_NEWLINK events for interfaces that appear after the plugin starts.  Interfaces that already exist at boot (e.g., virtio-net in QEMU) never generate events, so their conditions like net/eth0/exist were never set.

Moving enumeration to PLUGIN_INIT doesn't work because it runs before cond_init(), so the condition filesystem isn't ready yet.

Fix by registering an HOOK_SVC_PLUGIN callback that queries existing interfaces and routes.  This hook runs during conf_init(), after the condition system is initialized.

---

i recently added `ifupdown-ng` to my home server and decided this would be a reasonable `conditions` set: `<service/syslogd/ready,net/eth0/exist>` - everything worked great :+1:

when i made my `qemu` vm tests depend on the same `ifupdown-ng` configuration they failed because `net/eth0/exist` never came up. i did a little research and then asked `claude` to help me out on this... the patch seemed reasonable, makes sense _enough_ to me, works on my home server, and now my `qemu` vm tests pass

does this seem reasonable to you @troglobit?