### PR TITLE
Create mount points in fs_init() if they don't exist

### DIFF
--- a/src/finit.c
+++ b/src/finit.c
@@ -523,6 +523,10 @@ static void fs_init(void)
 		if (fismnt(fs[i].file))
 			continue;
 
+		/* Create mount point if it doesn't exist */
+		if (mkdir(fs[i].file, 0755) && errno != EEXIST)
+			warn("Failed creating mountpoint %s: %s", fs[i].file, strerror(errno));
+
 		fs_mount(fs[i].spec, fs[i].file, fs[i].type, 0, NULL);
 	}
 }


### PR DESCRIPTION
In containerized or virtualized environments, standard mount point directories may not exist at boot.  Ensure they are created before attempting to mount.

---

when running `finix` in a container we can skip stage 1 (initramfs) entirely - this change let's me boot _directly_ into `finit` in my stage 2 without the need for a shell script to `mkdir` and then call `finit`! :rocket: 