### PR TITLE
Add remain:yes option for run/task oneshot commands

### DIFF
--- a/doc/config/service-opts.md
+++ b/doc/config/service-opts.md
@@ -69,6 +69,11 @@ confines of that the following options are available:
   * `respawn` -- bypasses the `restart` mechanism completely, allows
     endless restarts.  Useful in many use-cases, but not what `service`
     was originally designed for so not the default behavior
+  * `remain:yes` -- for `run` and `task` only.  Prevents the task from
+    re-running on runlevel re-entry and ensures the `post:` script runs
+    when the task is explicitly stopped or leaves its valid runlevels.
+    Similar to systemd's `RemainAfterExit=yes`.  See [Task and Run](task-and-run.md)
+    for more details
   * `oncrash:reboot` -- when all retries have failed, and the service
     has *crashed*, if this option is set the system is rebooted
   * `oncrash:script` -- similarly, but instead of rebooting, call the

--- a/doc/config/task-and-run.md
+++ b/doc/config/task-and-run.md
@@ -44,3 +44,44 @@ redirects can be used:
 
 Please note, `;`, `&&`, `||`, and similar are *not supported*.  Any
 non-trivial constructs are better placed in a separate shell script.
+
+
+remain:yes
+----------
+
+By default, a `run` or `task` will re-run each time its runlevel is
+entered, and its `post:` script does not run on completion.
+
+With `remain:yes`, the task runs once and does not re-run on runlevel
+re-entry:
+
+    task [2345] remain:yes /usr/sbin/setup-firewall -- Firewall setup
+
+This has the following effects:
+
+  * The task does not re-run on runlevel re-entry
+  * The `post:` script runs when:
+    - The task is explicitly stopped (`initctl stop NAME`)
+    - The task leaves its valid runlevels (e.g., runlevel change)
+
+This is useful for tasks that set up persistent state where:
+
+  * Cleanup should only happen on explicit stop or when leaving valid runlevels
+  * The setup should not be re-run on every runlevel entry
+
+**Example:** Setting up firewall rules with cleanup on shutdown:
+
+```
+task [2345] remain:yes \
+     post:/usr/sbin/teardown-firewall \
+     /usr/sbin/setup-firewall -- Firewall setup
+```
+
+The firewall rules are created once.  The `post:` script runs when
+entering runlevel 0 (halt) or 6 (reboot), or on explicit stop.
+
+> [!NOTE]
+> The `remain:yes` option is not supported for bootstrap-only tasks
+> (tasks with only runlevel S).  Bootstrap tasks are deleted immediately
+> after completion, and their `post:` scripts never run.  A warning is
+> logged if `remain:yes` is used on such tasks.

--- a/man/finit.conf.5
+++ b/man/finit.conf.5
@@ -398,6 +398,20 @@ mechanism completely, allows endless restarts.  Useful in many
 use-cases, but not what
 .Cm service
 was originally designed for so not the default behavior.
+.It Cm remain:yes
+for
+.Cm run
+and
+.Cm task
+only.  Prevents the task from re-running on runlevel re-entry and
+ensures the
+.Cm post:
+script runs when the task is explicitly stopped or leaves its valid
+runlevels.  Similar to systemd's
+.Cm RemainAfterExit=yes .
+.Pp
+.Sy Note:
+not supported for bootstrap-only tasks (runlevels [S] only).
 .It Cm oncrash:reboot
 when all retries have failed, and the service
 has

--- a/src/sm.c
+++ b/src/sm.c
@@ -461,6 +461,9 @@ restart:
 		/* First reload all *.conf in /etc/finit.d/ */
 		conf_reload();
 
+		/* Handle remain tasks that need to run post script before restart */
+		service_runtask_clean();
+
 		/*
 		 * Then, mark all affected service conditions as in-flux and
 		 * let all affected services move to WAITING/HALTED

--- a/src/svc.c
+++ b/src/svc.c
@@ -344,6 +344,10 @@ svc_t *svc_stop_completed(void)
 	for (svc = svc_iterator(&iter, 1); svc; svc = svc_iterator(&iter, 0)) {
 		if (svc->state == SVC_STOPPING_STATE && svc->pid > 1)
 			return svc;
+
+		/* Also wait for remain tasks running their post script */
+		if (svc_is_remain(svc) && svc->state == SVC_TEARDOWN_STATE && svc->pid > 1)
+			return svc;
 	}
 
 	return NULL;

--- a/src/svc.h
+++ b/src/svc.h
@@ -139,6 +139,7 @@ typedef struct svc {
 	svc_type_t     type;	       /* Service, run, task, ... */
 	char           protect;        /* Services like dbus-daemon & udev by Finit */
 	char           manual;	       /* run/task that require `initctl start foo` */
+	char           remain;	       /* run/task: stay in DONE state, run post: on stop */
 	char           nowarn;	       /* Skip or log warning if cmd missing or conflicts */
 	const int      dirty;	       /* 0: unmodified, 1: modified */
 	const int      removed;
@@ -282,6 +283,7 @@ static inline int svc_is_tty       (svc_t *svc) { return svc && SVC_TYPE_TTY    
 static inline int svc_is_runtask   (svc_t *svc) { return svc && (SVC_TYPE_RUNTASK & svc->type);}
 static inline int svc_is_forking   (svc_t *svc) { return svc && svc->forking; }
 static inline int svc_is_manual    (svc_t *svc) { return svc && svc->manual; }
+static inline int svc_is_remain    (svc_t *svc) { return svc && svc->remain; }
 static inline int svc_is_noreload  (svc_t *svc) { return svc && (0 == svc->sighup && 0 == svc->reload_script[0]); }
 
 static inline int svc_in_runlevel  (svc_t *svc, int runlevel) { return svc && ISSET(svc->runlevels, runlevel); }


### PR DESCRIPTION
Similar to systemd's RemainAfterExit=yes.  Prevents the task from re-running on runlevel re-entry and ensures the post: script runs when explicitly stopped or when leaving valid runlevels.

Useful for tasks that set up persistent state like firewall rules:

    task [2345] remain:yes \
         post:/usr/sbin/teardown-firewall \
         /usr/sbin/setup-firewall -- Firewall setup

Not supported for bootstrap-only tasks (runlevel S only) since these are deleted immediately after completion.