### PR TITLE
tmpfiles.d: update /var/tmp mode

### DIFF
--- a/tmpfiles.d/var.conf
+++ b/tmpfiles.d/var.conf
@@ -8,7 +8,7 @@ d  /var/lib/alarm	0755 - - -
 d  /var/lib/misc	0755 - - -
 d  /var/lib/urandom	0755 - - -
 d  /var/spool		0755 - - -
-d  /var/tmp		0777 - - -
+d  /var/tmp		1777 - - -
 
 # Used by pam_console(8)
 d  /run/console              1777 - - -


### PR DESCRIPTION
`/var/tmp` mode should match `/tmp`


it isn't explicitly stated in the FHS standard that mode should be `1777` but the implication is there
additionally most distros set it to this value, as does `systemd`
i recently found that `flatpak` depends on these permissions, along with some other applications

---

@troglobit what do you think? is it reasonable to update this value here?